### PR TITLE
Add coverage analysis to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+
 jobs:
   test:
     name: Test Suite
@@ -41,6 +46,13 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Install coverage tools (Linux only)
+      if: matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lcov
+        pip install lcov_cobertura
+
     - name: Cache dependencies
       uses: actions/cache@v3
       with:
@@ -54,8 +66,69 @@ jobs:
     - name: Build project
       run: fpm build --verbose
 
-    - name: Run tests
-      run: fpm test --verbose
+    - name: Run tests (with coverage on Linux/GCC-12)
+      if: matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12
+      run: |
+        export OMP_NUM_THREADS=24
+        fpm clean --all
+        fpm test --profile debug --flag '-cpp -fprofile-arcs -ftest-coverage -g'
+
+    - name: Run tests (without coverage)
+      if: !(matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12)
+      run: |
+        export OMP_NUM_THREADS=24
+        fpm test --verbose
+
+    - name: Generate coverage data
+      if: matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12
+      run: |
+        # Generate lcov coverage data
+        lcov --capture --directory build/ --output-file coverage.info \
+          --rc branch_coverage=1 \
+          --ignore-errors inconsistent \
+          --ignore-errors mismatch \
+          --ignore-errors unused
+        
+        # Remove external dependencies and test files
+        lcov --remove coverage.info \
+          'build/dependencies/*' \
+          'test/*' \
+          '/usr/*' \
+          --output-file coverage_filtered.info \
+          --rc branch_coverage=1 \
+          --ignore-errors mismatch \
+          --ignore-errors unused
+        
+        # Convert to Cobertura XML
+        lcov_cobertura coverage_filtered.info --output cobertura.xml
+        
+        # Display coverage summary
+        lcov --summary coverage_filtered.info
+
+    - name: Coverage Report
+      if: matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12 && github.event_name == 'pull_request'
+      uses: insightsengineering/coverage-action@v3
+      continue-on-error: true
+      with:
+        path: ./cobertura.xml
+        threshold: 70
+        fail: true
+        publish: true
+        diff: true
+        diff-branch: main
+        diff-storage: _coverage_storage
+        coverage-summary-title: "Code Coverage Summary"
+        togglable-report: true
+        exclude-detailed-coverage: false
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest' && matrix.gcc-version == 12
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./cobertura.xml
+        flags: unittests
+        name: codecov-fluff
+        fail_ci_if_error: false
 
     - name: Run self-check (fluff on itself)
       run: |


### PR DESCRIPTION
## Summary
- Integrate coverage analysis into existing CI workflow (similar to fortfront)
- Only run coverage on ubuntu-latest with gcc-12 to avoid running tests twice
- Use OMP_NUM_THREADS=24 for all test runs as required

## Changes
- Add lcov/gcov coverage generation to test job
- Generate Cobertura XML for coverage reporting
- Add PR coverage reports with insightsengineering/coverage-action  
- Upload coverage to Codecov for tracking
- Coverage only runs on one matrix combination to save CI time

## Testing
- CI will run automatically on this PR
- Coverage report will be posted as PR comment