### PR TITLE
fix: correct test expectation for clean code diagnostics

### DIFF
--- a/test/test_lsp_diagnostics.f90
+++ b/test/test_lsp_diagnostics.f90
@@ -61,7 +61,7 @@ contains
             "    integer :: x" // new_line('a') // &
             "    x = 42" // new_line('a') // &
             "    print *, x" // new_line('a') // &
-            "end program", &
+            "end program test", &
             [""], 0)
             
         ! Test 4: Real diagnostic generation


### PR DESCRIPTION
## Summary
- Fixed test_lsp_diagnostics Clean code test that was incorrectly failing
- The test code used `end program` without the program name label, triggering F011 (missing end labels) rule
- Added program name to `end program test` to make it truly clean code

## Analysis of Test Failures

The sprint analyzed all test failures and categorized them:

### Fixed Bug
- **test_lsp_diagnostics Clean code test**: The test expected 0 diagnostics but got 1 (F011). The test input code was missing the program name on the end statement. This was a real test bug, now fixed.

### TDD Stubs (Expected to Fail)
All other failures are TDD stubs in RED phase - tests written before implementation:
- Dead code detection: impossible conditionals, unused procedures, error stop handling
- Formatter: roundtrip stability, complex expressions, array literals
- LSP: goto definition, document sync, path handling
- Cache: disk persistence
- CI: Jenkins integration

### F001 Verification
Verified the F001 (implicit none) rule works correctly:
- Missing implicit none: Correctly detects and reports F001
- With implicit none: No false positive

## Test Plan
- [x] `fpm test` passes (TDD stubs expected to fail)
- [x] Clean code test now reports PASS
- [x] F001 rule verified working correctly