### PR TITLE
fix: clarify performance rule test blocking reasons (P002-P007)

### DIFF
--- a/test/test_rule_p002_loop_ordering.f90
+++ b/test/test_rule_p002_loop_ordering.f90
@@ -6,25 +6,25 @@ program test_rule_p002_loop_ordering
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P002: Inefficient loop ordering rule..."
-    
+
     ! Test 1: Column-major inefficient ordering (should trigger)
     call test_column_major_inefficient()
-    
+
     ! Test 2: Row-major efficient ordering (should not trigger)
     call test_row_major_efficient()
-    
+
     ! Test 3: Multi-dimensional array access patterns
     call test_multidimensional_access()
-    
+
     ! Test 4: Cache-friendly loop ordering
     call test_cache_friendly_ordering()
-    
+
     print *, "All P002 tests passed!"
-    
+
 contains
-    
+
     subroutine test_column_major_inefficient()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,11 +32,12 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p002
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Column-major inefficient ordering (skipped - fortfront not available)"
+
+        ! BLOCKED: fortfront get_children returns empty arrays, preventing AST traversal
+        ! Rule implementation exists but cannot find nested loops without child traversal
+        print *, "  - Column-major inefficient ordering (blocked: fortfront child traversal)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer, parameter :: n = 1000, m = 1000" // new_line('a') // &
@@ -46,21 +47,21 @@ contains
                    "    ! Inefficient: accessing by rows in column-major Fortran" // new_line('a') // &
                    "    do i = 1, n" // new_line('a') // &
                    "        do j = 1, m" // new_line('a') // &
-                   "            matrix(i, j) = real(i * j)" // new_line('a') // & ! Bad access pattern
+                   "            matrix(i, j) = real(i * j)" // new_line('a') // &
                    "        end do" // new_line('a') // &
                    "    end do" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p002.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p002.f90", diagnostics, error_msg)
-        
+
         ! Check for P002 violation
         found_p002 = .false.
         if (allocated(diagnostics)) then
@@ -71,19 +72,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p002.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p002) then
             error stop "Failed: P002 should be triggered for inefficient loop ordering"
         end if
-        
-        print *, "  ✓ Column-major inefficient ordering"
-        
+
+        print *, "  + Column-major inefficient ordering"
+
     end subroutine test_column_major_inefficient
-    
+
     subroutine test_row_major_efficient()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -91,11 +92,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p002
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Row-major efficient ordering (skipped - fortfront not available)"
+
+        ! BLOCKED: fortfront get_children returns empty arrays, preventing AST traversal
+        print *, "  - Row-major efficient ordering (blocked: fortfront child traversal)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer, parameter :: n = 1000, m = 1000" // new_line('a') // &
@@ -105,21 +106,21 @@ contains
                    "    ! Efficient: accessing by columns in column-major Fortran" // new_line('a') // &
                    "    do j = 1, m" // new_line('a') // &
                    "        do i = 1, n" // new_line('a') // &
-                   "            matrix(i, j) = real(i * j)" // new_line('a') // & ! Good access pattern
+                   "            matrix(i, j) = real(i * j)" // new_line('a') // &
                    "        end do" // new_line('a') // &
                    "    end do" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p002_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p002_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P002 violation
         found_p002 = .false.
         if (allocated(diagnostics)) then
@@ -130,27 +131,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p002_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p002) then
             error stop "Failed: P002 should not be triggered for efficient loop ordering"
         end if
-        
-        print *, "  ✓ Row-major efficient ordering"
-        
+
+        print *, "  + Row-major efficient ordering"
+
     end subroutine test_row_major_efficient
-    
+
     subroutine test_multidimensional_access()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Multi-dimensional array access (skipped - fortfront not available)"
+        ! BLOCKED: fortfront get_children returns empty arrays
+        print *, "  - Multi-dimensional array access (blocked: fortfront child traversal)"
     end subroutine test_multidimensional_access
-    
+
     subroutine test_cache_friendly_ordering()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Cache-friendly loop ordering (skipped - fortfront not available)"
+        ! BLOCKED: fortfront get_children returns empty arrays
+        print *, "  - Cache-friendly loop ordering (blocked: fortfront child traversal)"
     end subroutine test_cache_friendly_ordering
-    
+
 end program test_rule_p002_loop_ordering

--- a/test/test_rule_p003_array_temporaries.f90
+++ b/test/test_rule_p003_array_temporaries.f90
@@ -6,25 +6,25 @@ program test_rule_p003_array_temporaries
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P003: Unnecessary array temporaries rule..."
-    
+
     ! Test 1: Unnecessary array temporaries (should trigger)
     call test_unnecessary_temporaries()
-    
+
     ! Test 2: Necessary array operations (should not trigger)
     call test_necessary_operations()
-    
+
     ! Test 3: Expression complexity causing temporaries
     call test_complex_expressions()
-    
+
     ! Test 4: Function return temporaries
     call test_function_temporaries()
-    
+
     print *, "All P003 tests passed!"
-    
+
 contains
-    
+
     subroutine test_unnecessary_temporaries()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,34 +32,35 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p003
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Unnecessary array temporaries (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations (see fluff_rules.f90 line 3332)
+        ! Requires fortfront AST API for array temporaries detection (issues #11-14)
+        print *, "  - Unnecessary array temporaries (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer, parameter :: n = 1000" // new_line('a') // &
                    "    real :: a(n), b(n), c(n), d(n)" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    ! This creates unnecessary temporaries" // new_line('a') // &
-                   "    a = b + c + d" // new_line('a') // &      ! Multiple temporaries
-                   "    b = a * 2.0 + c * 3.0" // new_line('a') // & ! More temporaries
+                   "    a = b + c + d" // new_line('a') // &
+                   "    b = a * 2.0 + c * 3.0" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    ! Complex expression creating many temporaries" // new_line('a') // &
                    "    c = (a + b) * (c + d) / 2.0" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p003.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p003.f90", diagnostics, error_msg)
-        
+
         ! Check for P003 violation
         found_p003 = .false.
         if (allocated(diagnostics)) then
@@ -70,19 +71,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p003.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p003) then
             error stop "Failed: P003 should be triggered for unnecessary array temporaries"
         end if
-        
-        print *, "  ✓ Unnecessary array temporaries"
-        
+
+        print *, "  + Unnecessary array temporaries"
+
     end subroutine test_unnecessary_temporaries
-    
+
     subroutine test_necessary_operations()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -90,11 +91,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p003
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Necessary array operations (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Necessary array operations (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer, parameter :: n = 1000" // new_line('a') // &
@@ -109,17 +110,17 @@ contains
                    "    ! Simple array assignments" // new_line('a') // &
                    "    b = a" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p003_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p003_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P003 violation
         found_p003 = .false.
         if (allocated(diagnostics)) then
@@ -130,27 +131,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p003_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p003) then
             error stop "Failed: P003 should not be triggered for necessary operations"
         end if
-        
-        print *, "  ✓ Necessary array operations"
-        
+
+        print *, "  + Necessary array operations"
+
     end subroutine test_necessary_operations
-    
+
     subroutine test_complex_expressions()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Complex expressions (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Complex expressions (blocked: rule not implemented)"
     end subroutine test_complex_expressions
-    
+
     subroutine test_function_temporaries()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Function return temporaries (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Function return temporaries (blocked: rule not implemented)"
     end subroutine test_function_temporaries
-    
+
 end program test_rule_p003_array_temporaries

--- a/test/test_rule_p004_pure_elemental.f90
+++ b/test/test_rule_p004_pure_elemental.f90
@@ -6,25 +6,25 @@ program test_rule_p004_pure_elemental
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P004: Missing pure/elemental declarations rule..."
-    
+
     ! Test 1: Functions that could be pure (should trigger)
     call test_could_be_pure()
-    
+
     ! Test 2: Functions already pure (should not trigger)
     call test_already_pure()
-    
+
     ! Test 3: Functions that could be elemental (should trigger)
     call test_could_be_elemental()
-    
+
     ! Test 4: Functions with side effects (should not trigger)
     call test_has_side_effects()
-    
+
     print *, "All P004 tests passed!"
-    
+
 contains
-    
+
     subroutine test_could_be_pure()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,11 +32,12 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p004
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Functions that could be pure (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation disabled with if (.false.) guard (see fluff_rules.f90 line 3770)
+        ! Requires fortfront AST API to check procedure attributes and analyze purity
+        print *, "  - Functions that could be pure (blocked: rule disabled in implementation)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "" // new_line('a') // &
@@ -57,17 +58,17 @@ contains
                    "    end function add_numbers" // new_line('a') // &
                    "" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p004.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p004.f90", diagnostics, error_msg)
-        
+
         ! Check for P004 violation
         found_p004 = .false.
         if (allocated(diagnostics)) then
@@ -78,19 +79,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p004.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p004) then
             error stop "Failed: P004 should be triggered for functions that could be pure"
         end if
-        
-        print *, "  ✓ Functions that could be pure"
-        
+
+        print *, "  + Functions that could be pure"
+
     end subroutine test_could_be_pure
-    
+
     subroutine test_already_pure()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -98,11 +99,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p004
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Functions already pure (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation disabled with if (.false.) guard
+        print *, "  - Functions already pure (blocked: rule disabled in implementation)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "" // new_line('a') // &
@@ -123,17 +124,17 @@ contains
                    "    end function add_numbers" // new_line('a') // &
                    "" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p004_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p004_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P004 violation
         found_p004 = .false.
         if (allocated(diagnostics)) then
@@ -144,27 +145,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p004_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p004) then
             error stop "Failed: P004 should not be triggered for already pure functions"
         end if
-        
-        print *, "  ✓ Functions already pure"
-        
+
+        print *, "  + Functions already pure"
+
     end subroutine test_already_pure
-    
+
     subroutine test_could_be_elemental()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Functions that could be elemental (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation disabled with if (.false.) guard
+        print *, "  - Functions that could be elemental (blocked: rule disabled in implementation)"
     end subroutine test_could_be_elemental
-    
+
     subroutine test_has_side_effects()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Functions with side effects (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation disabled with if (.false.) guard
+        print *, "  - Functions with side effects (blocked: rule disabled in implementation)"
     end subroutine test_has_side_effects
-    
+
 end program test_rule_p004_pure_elemental

--- a/test/test_rule_p005_string_operations.f90
+++ b/test/test_rule_p005_string_operations.f90
@@ -6,25 +6,25 @@ program test_rule_p005_string_operations
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P005: Inefficient string operations rule..."
-    
+
     ! Test 1: Inefficient string concatenation (should trigger)
     call test_inefficient_concatenation()
-    
+
     ! Test 2: Efficient string operations (should not trigger)
     call test_efficient_operations()
-    
+
     ! Test 3: String operations in loops
     call test_string_operations_in_loops()
-    
+
     ! Test 4: Repeated string allocations
     call test_repeated_allocations()
-    
+
     print *, "All P005 tests passed!"
-    
+
 contains
-    
+
     subroutine test_inefficient_concatenation()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,11 +32,12 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p005
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Inefficient string concatenation (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations (see fluff_rules.f90 line 3354)
+        ! Requires fortfront AST API for string operations efficiency check (issues #11-14)
+        print *, "  - Inefficient string concatenation (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    character(len=:), allocatable :: result" // new_line('a') // &
@@ -51,20 +52,20 @@ contains
                    "    ! Inefficient: string concatenation in loop" // new_line('a') // &
                    "    result = ''" // new_line('a') // &
                    "    do i = 1, 10" // new_line('a') // &
-                   "        result = result // 'item'" // new_line('a') // &  ! Very inefficient
+                   "        result = result // 'item'" // new_line('a') // &
                    "    end do" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p005.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p005.f90", diagnostics, error_msg)
-        
+
         ! Check for P005 violation
         found_p005 = .false.
         if (allocated(diagnostics)) then
@@ -75,19 +76,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p005.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p005) then
             error stop "Failed: P005 should be triggered for inefficient string operations"
         end if
-        
-        print *, "  ✓ Inefficient string concatenation"
-        
+
+        print *, "  + Inefficient string concatenation"
+
     end subroutine test_inefficient_concatenation
-    
+
     subroutine test_efficient_operations()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -95,11 +96,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p005
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Efficient string operations (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Efficient string operations (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    character(len=100) :: buffer" // new_line('a') // &
@@ -114,17 +115,17 @@ contains
                    "    ! Efficient: direct assignment" // new_line('a') // &
                    "    buffer = 'Static string'" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p005_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p005_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P005 violation
         found_p005 = .false.
         if (allocated(diagnostics)) then
@@ -135,27 +136,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p005_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p005) then
             error stop "Failed: P005 should not be triggered for efficient string operations"
         end if
-        
-        print *, "  ✓ Efficient string operations"
-        
+
+        print *, "  + Efficient string operations"
+
     end subroutine test_efficient_operations
-    
+
     subroutine test_string_operations_in_loops()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ String operations in loops (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - String operations in loops (blocked: rule not implemented)"
     end subroutine test_string_operations_in_loops
-    
+
     subroutine test_repeated_allocations()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Repeated string allocations (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Repeated string allocations (blocked: rule not implemented)"
     end subroutine test_repeated_allocations
-    
+
 end program test_rule_p005_string_operations

--- a/test/test_rule_p006_loop_allocations.f90
+++ b/test/test_rule_p006_loop_allocations.f90
@@ -6,25 +6,25 @@ program test_rule_p006_loop_allocations
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P006: Unnecessary allocations in loops rule..."
-    
+
     ! Test 1: Allocations inside loops (should trigger)
     call test_allocations_in_loops()
-    
+
     ! Test 2: Pre-allocated outside loops (should not trigger)
     call test_pre_allocated()
-    
+
     ! Test 3: Necessary allocations per iteration
     call test_necessary_per_iteration()
-    
+
     ! Test 4: String allocations in loops
     call test_string_allocations()
-    
+
     print *, "All P006 tests passed!"
-    
+
 contains
-    
+
     subroutine test_allocations_in_loops()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,11 +32,12 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p006
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Allocations inside loops (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations (see fluff_rules.f90 line 3365)
+        ! Requires fortfront AST API for loop allocations check (issues #11-14)
+        print *, "  - Allocations inside loops (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer :: i, n" // new_line('a') // &
@@ -48,25 +49,25 @@ contains
                    "    " // new_line('a') // &
                    "    ! Bad: allocating inside loop" // new_line('a') // &
                    "    do i = 1, 100" // new_line('a') // &
-                   "        allocate(temp_array(n))" // new_line('a') // &  ! Inefficient
+                   "        allocate(temp_array(n))" // new_line('a') // &
                    "        temp_array = real(i)" // new_line('a') // &
                    "        result = result + sum(temp_array)" // new_line('a') // &
-                   "        deallocate(temp_array)" // new_line('a') // &  ! Inefficient
+                   "        deallocate(temp_array)" // new_line('a') // &
                    "    end do" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    print *, result" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p006.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p006.f90", diagnostics, error_msg)
-        
+
         ! Check for P006 violation
         found_p006 = .false.
         if (allocated(diagnostics)) then
@@ -77,19 +78,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p006.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p006) then
             error stop "Failed: P006 should be triggered for allocations in loops"
         end if
-        
-        print *, "  ✓ Allocations inside loops"
-        
+
+        print *, "  + Allocations inside loops"
+
     end subroutine test_allocations_in_loops
-    
+
     subroutine test_pre_allocated()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -97,11 +98,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p006
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Pre-allocated outside loops (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Pre-allocated outside loops (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer :: i, n" // new_line('a') // &
@@ -122,17 +123,17 @@ contains
                    "    deallocate(temp_array)" // new_line('a') // &
                    "    print *, result" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p006_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p006_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P006 violation
         found_p006 = .false.
         if (allocated(diagnostics)) then
@@ -143,27 +144,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p006_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p006) then
             error stop "Failed: P006 should not be triggered for pre-allocated arrays"
         end if
-        
-        print *, "  ✓ Pre-allocated outside loops"
-        
+
+        print *, "  + Pre-allocated outside loops"
+
     end subroutine test_pre_allocated
-    
+
     subroutine test_necessary_per_iteration()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Necessary allocations per iteration (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Necessary allocations per iteration (blocked: rule not implemented)"
     end subroutine test_necessary_per_iteration
-    
+
     subroutine test_string_allocations()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ String allocations in loops (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - String allocations in loops (blocked: rule not implemented)"
     end subroutine test_string_allocations
-    
+
 end program test_rule_p006_loop_allocations

--- a/test/test_rule_p007_mixed_precision.f90
+++ b/test/test_rule_p007_mixed_precision.f90
@@ -6,25 +6,25 @@ program test_rule_p007_mixed_precision
     use fluff_diagnostics
     use fluff_ast
     implicit none
-    
+
     print *, "Testing P007: Mixed precision arithmetic rule..."
-    
+
     ! Test 1: Mixed precision operations (should trigger)
     call test_mixed_precision()
-    
+
     ! Test 2: Consistent precision (should not trigger)
     call test_consistent_precision()
-    
+
     ! Test 3: Necessary precision conversions
     call test_necessary_conversions()
-    
+
     ! Test 4: Complex mixed precision expressions
     call test_complex_mixed_expressions()
-    
+
     print *, "All P007 tests passed!"
-    
+
 contains
-    
+
     subroutine test_mixed_precision()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -32,11 +32,12 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p007
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Mixed precision operations (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations (see fluff_rules.f90 line 3376)
+        ! Requires fortfront AST API for mixed precision arithmetic check (issues #11-14)
+        print *, "  - Mixed precision operations (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    real :: single_val" // new_line('a') // &
@@ -47,25 +48,25 @@ contains
                    "    double_val = 2.71828d0" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    ! Mixed precision - inefficient conversions" // new_line('a') // &
-                   "    result = single_val + double_val" // new_line('a') // &  ! Mixed precision
-                   "    result = result * double_val" // new_line('a') // &      ! More mixing
+                   "    result = single_val + double_val" // new_line('a') // &
+                   "    result = result * double_val" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    ! Complex expression with mixed types" // new_line('a') // &
                    "    result = sin(single_val) + cos(double_val)" // new_line('a') // &
                    "    " // new_line('a') // &
                    "    print *, result" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p007.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p007.f90", diagnostics, error_msg)
-        
+
         ! Check for P007 violation
         found_p007 = .false.
         if (allocated(diagnostics)) then
@@ -76,19 +77,19 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p007.f90", status="old")
         close(99, status="delete")
-        
+
         if (.not. found_p007) then
             error stop "Failed: P007 should be triggered for mixed precision arithmetic"
         end if
-        
-        print *, "  ✓ Mixed precision operations"
-        
+
+        print *, "  + Mixed precision operations"
+
     end subroutine test_mixed_precision
-    
+
     subroutine test_consistent_precision()
         type(linter_engine_t) :: linter
         type(diagnostic_t), allocatable :: diagnostics(:)
@@ -96,11 +97,11 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_p007
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Consistent precision (skipped - fortfront not available)"
+
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Consistent precision (blocked: rule not implemented)"
         return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    real :: val1, val2, result" // new_line('a') // &
@@ -115,17 +116,17 @@ contains
                    "    " // new_line('a') // &
                    "    print *, result" // new_line('a') // &
                    "end program test"
-        
+
         linter = create_linter_engine()
-        
+
         ! Create temporary file
         open(unit=99, file="test_p007_ok.f90", status="replace")
         write(99, '(A)') test_code
         close(99)
-        
+
         ! Lint the file
         call linter%lint_file("test_p007_ok.f90", diagnostics, error_msg)
-        
+
         ! Check for P007 violation
         found_p007 = .false.
         if (allocated(diagnostics)) then
@@ -136,27 +137,27 @@ contains
                 end if
             end do
         end if
-        
+
         ! Clean up
         open(unit=99, file="test_p007_ok.f90", status="old")
         close(99, status="delete")
-        
+
         if (found_p007) then
             error stop "Failed: P007 should not be triggered for consistent precision"
         end if
-        
-        print *, "  ✓ Consistent precision"
-        
+
+        print *, "  + Consistent precision"
+
     end subroutine test_consistent_precision
-    
+
     subroutine test_necessary_conversions()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Necessary precision conversions (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Necessary precision conversions (blocked: rule not implemented)"
     end subroutine test_necessary_conversions
-    
+
     subroutine test_complex_mixed_expressions()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Complex mixed precision expressions (skipped - fortfront not available)"
+        ! BLOCKED: Rule implementation returns empty violations
+        print *, "  - Complex mixed precision expressions (blocked: rule not implemented)"
     end subroutine test_complex_mixed_expressions
-    
+
 end program test_rule_p007_mixed_precision


### PR DESCRIPTION
## Summary
- Update P002-P007 test skip messages to explain actual blocking reasons
- P002: fortfront get_children returns empty arrays, blocking AST traversal
- P003, P005, P006, P007: Rule implementations return empty violations (not implemented)
- P004: Rule implementation disabled with if (.false.) guard
- F001: Already fully AST-based and passing (verified)

## Analysis
Investigation revealed:
1. fortfront AST parses correctly and detects root node
2. However, get_children returns empty arrays, preventing tree traversal
3. This is why P002 (loop ordering) cannot find nested loops
4. P003/P005/P006/P007 are explicitly marked BLOCKED in fluff_rules.f90
5. P004 has implementation but is disabled with if (.false.) guard

## Test plan
- [x] All tests pass (fpm test)
- [x] P002-P007 tests show clear blocking reasons in output
- [x] F001 tests fully enabled and passing