### PR TITLE
fix: enable working tests for F010-F013 style rules

### DIFF
--- a/test/test_rule_f010_obsolete_features.f90
+++ b/test/test_rule_f010_obsolete_features.f90
@@ -32,11 +32,7 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_f010
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ GOTO statement (skipped - fortfront not available)"
-        return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer :: x" // new_line('a') // &
@@ -74,9 +70,9 @@ contains
         if (.not. found_f010) then
             error stop "Failed: F010 should be triggered for GOTO statement"
         end if
-        
-        print *, "  ✓ GOTO statement"
-        
+
+        print *, "  GOTO statement"
+
     end subroutine test_goto_statement
     
     subroutine test_computed_goto()
@@ -86,11 +82,7 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_f010
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Computed GOTO (skipped - fortfront not available)"
-        return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer :: choice" // new_line('a') // &
@@ -133,9 +125,9 @@ contains
         if (.not. found_f010) then
             error stop "Failed: F010 should be triggered for computed GOTO"
         end if
-        
-        print *, "  ✓ Computed GOTO"
-        
+
+        print *, "  Computed GOTO"
+
     end subroutine test_computed_goto
     
     subroutine test_modern_control_flow()
@@ -145,11 +137,7 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_f010
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Modern control flow (skipped - fortfront not available)"
-        return
-        
+
         test_code = "program test" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "    integer :: x, choice" // new_line('a') // &
@@ -198,14 +186,14 @@ contains
         if (found_f010) then
             error stop "Failed: F010 should not be triggered for modern control flow"
         end if
-        
-        print *, "  ✓ Modern control flow"
-        
+
+        print *, "  Modern control flow"
+
     end subroutine test_modern_control_flow
-    
+
     subroutine test_arithmetic_if()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Arithmetic IF statement (skipped - fortfront not available)"
+        ! Arithmetic IF test placeholder (advanced obsolete feature)
+        print *, "  Arithmetic IF statement (not implemented)"
     end subroutine test_arithmetic_if
-    
+
 end program test_rule_f010_obsolete_features

--- a/test/test_rule_f011_missing_end_labels.f90
+++ b/test/test_rule_f011_missing_end_labels.f90
@@ -32,11 +32,7 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_f011
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Missing end labels (skipped - fortfront not available)"
-        return
-        
+
         test_code = "program test_prog" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "" // new_line('a') // &
@@ -83,9 +79,9 @@ contains
         if (.not. found_f011) then
             error stop "Failed: F011 should be triggered for missing end labels"
         end if
-        
-        print *, "  ✓ Missing end labels"
-        
+
+        print *, "  Missing end labels"
+
     end subroutine test_missing_end_labels
     
     subroutine test_proper_end_labels()
@@ -95,11 +91,7 @@ contains
         character(len=:), allocatable :: test_code
         integer :: i
         logical :: found_f011
-        
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Proper end labels (skipped - fortfront not available)"
-        return
-        
+
         test_code = "program test_prog" // new_line('a') // &
                    "    implicit none" // new_line('a') // &
                    "" // new_line('a') // &
@@ -146,19 +138,19 @@ contains
         if (found_f011) then
             error stop "Failed: F011 should not be triggered for proper end labels"
         end if
-        
-        print *, "  ✓ Proper end labels"
-        
+
+        print *, "  Proper end labels"
+
     end subroutine test_proper_end_labels
-    
+
     subroutine test_mixed_end_labels()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Mixed end labels (skipped - fortfront not available)"
+        ! Mixed end labels test (advanced)
+        print *, "  Mixed end labels (not implemented)"
     end subroutine test_mixed_end_labels
-    
+
     subroutine test_function_end_labels()
-        ! Skip test if fortfront not available
-        print *, "  ⚠ Function end labels (skipped - fortfront not available)"
+        ! Function end labels test (advanced)
+        print *, "  Function end labels (not implemented)"
     end subroutine test_function_end_labels
-    
+
 end program test_rule_f011_missing_end_labels

--- a/test/test_rule_f012_naming_conventions.f90
+++ b/test/test_rule_f012_naming_conventions.f90
@@ -77,7 +77,7 @@ contains
             error stop "Failed: F012 should be triggered for inconsistent naming"
         end if
         
-        print *, "  ✓ Inconsistent variable naming"
+        print *, "  Inconsistent variable naming"
         
     end subroutine test_inconsistent_variable_naming
     
@@ -133,7 +133,7 @@ contains
             error stop "Failed: F012 should not be triggered for consistent snake_case"
         end if
         
-        print *, "  ✓ Consistent snake_case"
+        print *, "  Consistent snake_case"
         
     end subroutine test_consistent_snake_case
     
@@ -189,7 +189,7 @@ contains
             error stop "Failed: F012 should not be triggered for consistent camelCase"
         end if
         
-        print *, "  ✓ Consistent camelCase"
+        print *, "  Consistent camelCase"
         
     end subroutine test_consistent_camel_case
     
@@ -244,7 +244,7 @@ contains
             error stop "Failed: F012 should be triggered for mixed naming styles"
         end if
         
-        print *, "  ✓ Mixed naming styles"
+        print *, "  Mixed naming styles"
         
     end subroutine test_mixed_naming_styles
     

--- a/test/test_rule_f013_multiple_statements.f90
+++ b/test/test_rule_f013_multiple_statements.f90
@@ -72,7 +72,7 @@ contains
             error stop "Failed: F013 should be triggered for multiple statements per line"
         end if
         
-        print *, "  ✓ Multiple statements per line"
+        print *, "  Multiple statements per line"
         
     end subroutine test_multiple_statements
     
@@ -128,7 +128,7 @@ contains
             error stop "Failed: F013 should not be triggered for single statements per line"
         end if
         
-        print *, "  ✓ Single statements per line"
+        print *, "  Single statements per line"
         
     end subroutine test_single_statements
     
@@ -178,7 +178,7 @@ contains
             error stop "Failed: F013 should be triggered for semicolon separated statements"
         end if
         
-        print *, "  ✓ Semicolon separated statements"
+        print *, "  Semicolon separated statements"
         
     end subroutine test_semicolon_statements
     
@@ -230,7 +230,7 @@ contains
             error stop "Failed: F013 should be triggered for complex multi-statement lines"
         end if
         
-        print *, "  ✓ Complex multi-statement lines"
+        print *, "  Complex multi-statement lines"
         
     end subroutine test_complex_multi_statements
     


### PR DESCRIPTION
## Summary
Enable tests for style rules F010-F013 that were incorrectly skipped. The implementations work but tests had `return` statements preventing execution.

## Changes
- **F010** (Obsolete Features): Removed skip `return` from `test_goto_statement()`, `test_computed_goto()`, `test_modern_control_flow()`
- **F011** (Missing End Labels): Removed skip `return` from `test_missing_end_labels()`, `test_proper_end_labels()`
- **F012/F013**: Cleaned up emoji characters per CLAUDE.md rules
- Updated placeholder messages to remove "blocked" language

## Test Plan
- [x] All F010 tests pass
- [x] All F011 tests pass
- [x] All F012 tests pass
- [x] All F013 tests pass
- [x] Full test suite passes