### PR TITLE
fix: restore strict F009 and perf rule tests

### DIFF
--- a/src/fluff_rules/fluff_rule_f009.f90
+++ b/src/fluff_rules/fluff_rule_f009.f90
@@ -1,0 +1,233 @@
+module fluff_rule_f009
+    use fluff_ast, only: fluff_ast_context_t, NODE_ASSIGNMENT, NODE_DECLARATION
+    use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
+    use fluff_core, only: source_range_t
+    use fortfront, only: assignment_node, call_or_subscript_node, declaration_node, &
+                         identifier_node
+    implicit none
+    private
+
+    public :: check_f009_inconsistent_intent_impl
+
+    type :: intent_var_t
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: intent
+        type(source_range_t) :: decl_location
+        logical :: was_assigned = .false.
+    end type intent_var_t
+
+contains
+
+    subroutine check_f009_inconsistent_intent_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(intent_var_t), allocatable :: intents(:)
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+        integer :: i
+
+        allocate (intents(0))
+        allocate (tmp(32))
+        violation_count = 0
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (n => ctx%arena%entries(i)%node)
+            type is (declaration_node)
+                call add_declaration_intents(ctx, i, intents)
+            end select
+        end do
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (n => ctx%arena%entries(i)%node)
+            type is (assignment_node)
+                call handle_assignment_node(ctx, i, intents, tmp, violation_count)
+            end select
+        end do
+
+        call add_unassigned_out(intents, tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) then
+            violations = tmp(1:violation_count)
+        end if
+    end subroutine check_f009_inconsistent_intent_impl
+
+    subroutine add_declaration_intents(ctx, node_index, intents)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(intent_var_t), allocatable, intent(inout) :: intents(:)
+
+        integer :: i
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: intent_lc
+
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (node => ctx%arena%entries(node_index)%node)
+        type is (declaration_node)
+            if (.not. node%has_intent) return
+            intent_lc = to_lower_ascii(trim(node%intent))
+
+            if (node%is_multi_declaration .and. allocated(node%var_names)) then
+                do i = 1, size(node%var_names)
+                    name = to_lower_ascii(trim(node%var_names(i)))
+                    call upsert_intent(intents, name, intent_lc, &
+                                       ctx%get_node_location(node_index))
+                end do
+            else if (allocated(node%var_name)) then
+                name = to_lower_ascii(trim(node%var_name))
+                call upsert_intent(intents, name, intent_lc, &
+                                   ctx%get_node_location(node_index))
+            end if
+        end select
+    end subroutine add_declaration_intents
+
+    subroutine handle_assignment_node(ctx, node_index, intents, tmp, violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(intent_var_t), allocatable, intent(inout) :: intents(:)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: target_index
+        character(len=:), allocatable :: target
+
+        select type (a => ctx%arena%entries(node_index)%node)
+        type is (assignment_node)
+            target_index = a%target_index
+        class default
+            target_index = 0
+        end select
+
+        if (target_index <= 0) then
+            return
+        end if
+
+        call get_lhs_base_name(ctx, target_index, target)
+        if (.not. allocated(target)) return
+
+        target = to_lower_ascii(trim(target))
+        call handle_assignment_to_target(target, &
+                                         ctx%get_node_location(node_index), intents, &
+                                         tmp, violation_count)
+    end subroutine handle_assignment_node
+
+    subroutine get_lhs_base_name(ctx, lhs_index, name)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: lhs_index
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ""
+        if (lhs_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(lhs_index)%node)) return
+
+        select type (lhs => ctx%arena%entries(lhs_index)%node)
+        type is (identifier_node)
+            if (allocated(lhs%name)) name = lhs%name
+        type is (call_or_subscript_node)
+            if (allocated(lhs%name)) name = lhs%name
+        end select
+    end subroutine get_lhs_base_name
+
+    subroutine handle_assignment_to_target(target, location, intents, tmp, &
+                                           violation_count)
+        character(len=*), intent(in) :: target
+        type(source_range_t), intent(in) :: location
+        type(intent_var_t), allocatable, intent(inout) :: intents(:)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i
+
+        do i = 1, size(intents)
+            if (intents(i)%name == target) then
+                intents(i)%was_assigned = .true.
+                if (intents(i)%intent == "in") then
+                    call push_violation(tmp, violation_count, create_diagnostic( &
+                                        code="F009", &
+                                 message="Do not assign to intent(in) dummy argument", &
+                                        file_path="", &
+                                        location=location, &
+                                        severity=SEVERITY_WARNING))
+                end if
+                exit
+            end if
+        end do
+    end subroutine handle_assignment_to_target
+
+    subroutine add_unassigned_out(intents, tmp, violation_count)
+        type(intent_var_t), allocatable, intent(in) :: intents(:)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i
+
+        do i = 1, size(intents)
+            if (intents(i)%intent == "out" .and. .not. intents(i)%was_assigned) then
+                call push_violation(tmp, violation_count, create_diagnostic( &
+                                    code="F009", &
+                               message="intent(out) dummy argument is never assigned", &
+                                    file_path="", &
+                                    location=intents(i)%decl_location, &
+                                    severity=SEVERITY_WARNING))
+            end if
+        end do
+    end subroutine add_unassigned_out
+
+    subroutine upsert_intent(intents, name, intent, decl_location)
+        type(intent_var_t), allocatable, intent(inout) :: intents(:)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: intent
+        type(source_range_t), intent(in) :: decl_location
+
+        integer :: i
+
+        do i = 1, size(intents)
+            if (intents(i)%name == name) then
+                intents(i)%intent = intent
+                intents(i)%decl_location = decl_location
+                return
+            end if
+        end do
+
+        intents = [intents, intent_var_t(name=name, intent=intent, &
+                                         decl_location=decl_location)]
+    end subroutine upsert_intent
+
+    subroutine push_violation(tmp, count, diag)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: count
+        type(diagnostic_t), intent(in) :: diag
+
+        type(diagnostic_t), allocatable :: grown(:)
+
+        if (count >= size(tmp)) then
+            allocate (grown(max(2*size(tmp), 8)))
+            if (count > 0) grown(1:count) = tmp(1:count)
+            call move_alloc(grown, tmp)
+        end if
+
+        count = count + 1
+        tmp(count) = diag
+    end subroutine push_violation
+
+    pure function to_lower_ascii(s) result(out)
+        character(len=*), intent(in) :: s
+        character(len=len(s)) :: out
+
+        integer :: i, c
+
+        out = s
+        do i = 1, len(s)
+            c = iachar(s(i:i))
+            if (c >= iachar("A") .and. c <= iachar("Z")) then
+                out(i:i) = achar(c + 32)
+            end if
+        end do
+    end function to_lower_ascii
+
+end module fluff_rule_f009

--- a/src/fluff_rules/fluff_rule_perf.f90
+++ b/src/fluff_rules/fluff_rule_perf.f90
@@ -1,0 +1,924 @@
+module fluff_rule_perf
+    use fluff_ast, only: fluff_ast_context_t, NODE_FUNCTION_DEF, NODE_SUBROUTINE_DEF
+    use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO, &
+                                 SEVERITY_WARNING
+    use fluff_core, only: source_range_t
+    use fortfront, only: assignment_node, binary_op_node, call_or_subscript_node, &
+                         declaration_node, do_loop_node, function_def_node, &
+                         identifier_node, literal_node, subroutine_def_node, &
+                         allocate_statement_node, subroutine_call_node, &
+                         print_statement_node, write_statement_node, &
+                         read_statement_node, stop_node, error_stop_node
+    implicit none
+    private
+
+    public :: check_p002_loop_ordering_impl
+    public :: check_p003_array_temporaries_impl
+    public :: check_p004_pure_elemental_impl
+    public :: check_p005_string_operations_impl
+    public :: check_p006_loop_allocations_impl
+    public :: check_p007_mixed_precision_impl
+
+    type :: var_prop_t
+        character(len=:), allocatable :: name
+        logical :: is_array = .false.
+        integer :: real_kind = -1
+    end type var_prop_t
+
+contains
+
+    subroutine check_p002_loop_ordering_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+
+        allocate (tmp(16))
+        violation_count = 0
+
+        call analyze_p002(ctx, node_index, "", tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p002_loop_ordering_impl
+
+    recursive subroutine analyze_p002(ctx, node_index, outer_var, tmp, &
+                                      violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: outer_var
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i, j
+        character(len=:), allocatable :: v_outer, v_inner
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (outer_loop => ctx%arena%entries(i)%node)
+            type is (do_loop_node)
+                if (.not. allocated(outer_loop%var_name)) cycle
+                if (.not. allocated(outer_loop%body_indices)) cycle
+                v_outer = to_lower_ascii(trim(outer_loop%var_name))
+
+                do j = 1, size(outer_loop%body_indices)
+              if (.not. allocated(ctx%arena%entries(outer_loop%body_indices(j))%node)) &
+                        cycle
+                    select type (inner_loop => &
+                                 ctx%arena%entries(outer_loop%body_indices(j))%node)
+                    type is (do_loop_node)
+                        if (.not. allocated(inner_loop%var_name)) cycle
+                        v_inner = to_lower_ascii(trim(inner_loop%var_name))
+                        if (loop_has_inefficient_access(ctx, &
+                                                        outer_loop%body_indices(j), &
+                                                        v_outer, v_inner)) then
+                            call push_violation(tmp, violation_count, &
+                                                create_diagnostic( &
+                                                code="P002", &
+                     message="Consider swapping nested loops for column-major access", &
+                                                file_path="", &
+                           location=ctx%get_node_location(outer_loop%body_indices(j)), &
+                                                severity=SEVERITY_INFO))
+                            exit
+                        end if
+                    end select
+                end do
+            end select
+        end do
+    end subroutine analyze_p002
+
+    function loop_has_inefficient_access(ctx, loop_index, outer_var, inner_var) &
+        result(found)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: loop_index
+        character(len=*), intent(in) :: outer_var
+        character(len=*), intent(in) :: inner_var
+        logical :: found
+
+        integer :: i
+
+        found = .false.
+        if (loop_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(loop_index)%node)) return
+
+        select type (loop => ctx%arena%entries(loop_index)%node)
+        type is (do_loop_node)
+            if (.not. allocated(loop%body_indices)) return
+            do i = 1, size(loop%body_indices)
+                if (node_has_inefficient_access(ctx, loop%body_indices(i), &
+                                                outer_var, inner_var)) then
+                    found = .true.
+                    exit
+                end if
+            end do
+        end select
+    end function loop_has_inefficient_access
+
+    recursive function node_has_inefficient_access(ctx, node_index, outer_var, &
+                                                   inner_var) &
+        result(found)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: outer_var
+        character(len=*), intent(in) :: inner_var
+        logical :: found
+
+        integer :: i
+
+        found = .false.
+        if (node_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (n => ctx%arena%entries(node_index)%node)
+        type is (call_or_subscript_node)
+            if (is_inefficient_2d_access(ctx, node_index, outer_var, &
+                                         inner_var)) then
+                found = .true.
+                return
+            end if
+            if (allocated(n%arg_indices)) then
+                do i = 1, size(n%arg_indices)
+                    if (node_has_inefficient_access(ctx, n%arg_indices(i), &
+                                                    outer_var, inner_var)) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        type is (assignment_node)
+            if (node_has_inefficient_access(ctx, n%target_index, outer_var, &
+                                            inner_var)) then
+                found = .true.
+                return
+            end if
+            if (node_has_inefficient_access(ctx, n%value_index, outer_var, &
+                                            inner_var)) then
+                found = .true.
+                return
+            end if
+        type is (binary_op_node)
+            if (node_has_inefficient_access(ctx, n%left_index, outer_var, &
+                                            inner_var)) then
+                found = .true.
+                return
+            end if
+            if (node_has_inefficient_access(ctx, n%right_index, outer_var, &
+                                            inner_var)) then
+                found = .true.
+                return
+            end if
+        type is (do_loop_node)
+            if (allocated(n%body_indices)) then
+                do i = 1, size(n%body_indices)
+                    if (node_has_inefficient_access(ctx, n%body_indices(i), &
+                                                    outer_var, inner_var)) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        end select
+    end function node_has_inefficient_access
+
+    function is_inefficient_2d_access(ctx, node_index, outer_var, inner_var) result(bad)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: outer_var
+        character(len=*), intent(in) :: inner_var
+        logical :: bad
+
+        integer :: a1, a2
+        character(len=:), allocatable :: n1, n2
+
+        bad = .false.
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (c => ctx%arena%entries(node_index)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(c%arg_indices)) return
+            if (size(c%arg_indices) < 2) return
+            a1 = c%arg_indices(1)
+            a2 = c%arg_indices(2)
+        class default
+            return
+        end select
+
+        call get_identifier_arg_name(ctx, a1, n1)
+        call get_identifier_arg_name(ctx, a2, n2)
+        if (.not. allocated(n1) .or. .not. allocated(n2)) return
+
+        if (n1 == outer_var .and. n2 == inner_var) then
+            bad = .true.
+        end if
+    end function is_inefficient_2d_access
+
+    subroutine get_identifier_arg_name(ctx, node_index, name)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+
+        name = ""
+        if (node_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (n => ctx%arena%entries(node_index)%node)
+        type is (identifier_node)
+            if (allocated(n%name)) name = to_lower_ascii(trim(n%name))
+        end select
+    end subroutine get_identifier_arg_name
+
+    subroutine check_p003_array_temporaries_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(var_prop_t), allocatable :: props(:)
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+
+        allocate (props(0))
+        allocate (tmp(16))
+        violation_count = 0
+
+        call collect_var_props(ctx, node_index, props)
+        call analyze_p003(ctx, node_index, props, tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p003_array_temporaries_impl
+
+    recursive subroutine analyze_p003(ctx, node_index, props, tmp, violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (n => ctx%arena%entries(i)%node)
+            type is (assignment_node)
+                if (is_whole_array_binary_assignment(ctx, i, props)) then
+                    call push_violation(tmp, violation_count, create_diagnostic( &
+                                        code="P003", &
+                              message="Whole-array expression may create temporaries", &
+                                        file_path="", &
+                                        location=ctx%get_node_location(i), &
+                                        severity=SEVERITY_INFO))
+                end if
+            end select
+        end do
+    end subroutine analyze_p003
+
+    function is_whole_array_binary_assignment(ctx, node_index, props) result(is_bad)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        logical :: is_bad
+
+        integer :: target_idx, value_idx
+        character(len=:), allocatable :: tname, l1, l2
+        character(len=:), allocatable :: op
+
+        is_bad = .false.
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (a => ctx%arena%entries(node_index)%node)
+        type is (assignment_node)
+            target_idx = a%target_index
+            value_idx = a%value_index
+        class default
+            return
+        end select
+
+        call get_identifier_arg_name(ctx, target_idx, tname)
+        if (.not. allocated(tname)) return
+        if (.not. prop_is_array(props, tname)) return
+
+        if (value_idx <= 0) return
+        if (.not. allocated(ctx%arena%entries(value_idx)%node)) return
+
+        select type (b => ctx%arena%entries(value_idx)%node)
+        type is (binary_op_node)
+            if (.not. allocated(b%operator)) return
+            op = trim(b%operator)
+            if (op /= "+" .and. op /= "-" .and. op /= "*" .and. op /= "/") return
+            call get_identifier_arg_name(ctx, b%left_index, l1)
+            call get_identifier_arg_name(ctx, b%right_index, l2)
+        class default
+            return
+        end select
+
+        if (.not. allocated(l1) .or. .not. allocated(l2)) return
+        if (prop_is_array(props, l1) .and. prop_is_array(props, l2)) then
+            is_bad = .true.
+        end if
+    end function is_whole_array_binary_assignment
+
+    subroutine check_p004_pure_elemental_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+        integer :: i
+
+        allocate (tmp(16))
+        violation_count = 0
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            if (ctx%get_node_type(i) == NODE_FUNCTION_DEF .or. &
+                ctx%get_node_type(i) == NODE_SUBROUTINE_DEF) then
+                if (procedure_is_pure_candidate(ctx, i)) then
+                    call push_violation(tmp, violation_count, create_diagnostic( &
+                                        code="P004", &
+                            message="Consider adding pure attribute for optimization", &
+                                        file_path="", &
+                                        location=ctx%get_node_location(i), &
+                                        severity=SEVERITY_INFO))
+                end if
+            end if
+        end do
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p004_pure_elemental_impl
+
+    function procedure_is_pure_candidate(ctx, node_index) result(ok)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical :: ok
+
+        ok = .false.
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (p => ctx%arena%entries(node_index)%node)
+        type is (function_def_node)
+            if (has_prefix(p%prefix_keywords, "pure")) return
+            if (procedure_has_side_effects(ctx, node_index)) return
+            ok = .true.
+        type is (subroutine_def_node)
+            if (has_prefix(p%prefix_keywords, "pure")) return
+            if (procedure_has_side_effects(ctx, node_index)) return
+            ok = .true.
+        end select
+    end function procedure_is_pure_candidate
+
+    recursive function procedure_has_side_effects(ctx, node_index) result(has)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical :: has
+
+        integer, allocatable :: children(:)
+        integer :: i
+
+        has = .false.
+        if (node_index <= 0) return
+
+        if (allocated(ctx%arena%entries(node_index)%node)) then
+            select type (n => ctx%arena%entries(node_index)%node)
+            type is (print_statement_node)
+                has = .true.
+                return
+            type is (write_statement_node)
+                has = .true.
+                return
+            type is (read_statement_node)
+                has = .true.
+                return
+            type is (allocate_statement_node)
+                has = .true.
+                return
+            type is (subroutine_call_node)
+                has = .true.
+                return
+            type is (stop_node)
+                has = .true.
+                return
+            type is (error_stop_node)
+                has = .true.
+                return
+            end select
+        end if
+
+        children = ctx%get_children(node_index)
+        do i = 1, size(children)
+            if (children(i) > 0) then
+                if (procedure_has_side_effects(ctx, children(i))) then
+                    has = .true.
+                    exit
+                end if
+            end if
+        end do
+        if (allocated(children)) deallocate (children)
+    end function procedure_has_side_effects
+
+    subroutine check_p005_string_operations_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+
+        allocate (tmp(16))
+        violation_count = 0
+
+        call analyze_p005(ctx, node_index, .false., tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p005_string_operations_impl
+
+    recursive subroutine analyze_p005(ctx, node_index, in_loop, tmp, violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical, intent(in) :: in_loop
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i, j
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (loop => ctx%arena%entries(i)%node)
+            type is (do_loop_node)
+                if (.not. allocated(loop%body_indices)) cycle
+                do j = 1, size(loop%body_indices)
+                    if (node_has_concat(ctx, loop%body_indices(j))) then
+                        call push_violation(tmp, violation_count, create_diagnostic( &
+                                            code="P005", &
+                             message="String concatenation in loops can be expensive", &
+                                            file_path="", &
+                                            location=ctx%get_node_location(i), &
+                                            severity=SEVERITY_INFO))
+                        exit
+                    end if
+                end do
+            end select
+        end do
+    end subroutine analyze_p005
+
+    function binary_op_is_concat(ctx, node_index) result(is_concat)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical :: is_concat
+
+        is_concat = .false.
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+        select type (b => ctx%arena%entries(node_index)%node)
+        type is (binary_op_node)
+            if (allocated(b%operator)) then
+                is_concat = (trim(b%operator) == "//")
+            end if
+        end select
+    end function binary_op_is_concat
+
+    subroutine check_p006_loop_allocations_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+
+        allocate (tmp(16))
+        violation_count = 0
+
+        call analyze_p006(ctx, node_index, .false., tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p006_loop_allocations_impl
+
+    recursive subroutine analyze_p006(ctx, node_index, in_loop, tmp, violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical, intent(in) :: in_loop
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i, j
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (loop => ctx%arena%entries(i)%node)
+            type is (do_loop_node)
+                if (.not. allocated(loop%body_indices)) cycle
+                do j = 1, size(loop%body_indices)
+                    if (node_has_allocate(ctx, loop%body_indices(j))) then
+                        call push_violation(tmp, violation_count, create_diagnostic( &
+                                            code="P006", &
+                                            message="Avoid allocate inside loops", &
+                                            file_path="", &
+                                            location=ctx%get_node_location(i), &
+                                            severity=SEVERITY_WARNING))
+                        exit
+                    end if
+                end do
+            end select
+        end do
+    end subroutine analyze_p006
+
+    subroutine check_p007_mixed_precision_impl(ctx, node_index, violations)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+        type(var_prop_t), allocatable :: props(:)
+        type(diagnostic_t), allocatable :: tmp(:)
+        integer :: violation_count
+
+        allocate (props(0))
+        allocate (tmp(16))
+        violation_count = 0
+
+        call collect_var_props(ctx, node_index, props)
+        call analyze_p007(ctx, node_index, props, tmp, violation_count)
+
+        allocate (violations(violation_count))
+        if (violation_count > 0) violations = tmp(1:violation_count)
+    end subroutine check_p007_mixed_precision_impl
+
+    recursive subroutine analyze_p007(ctx, node_index, props, tmp, violation_count)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+
+        integer :: i
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (b => ctx%arena%entries(i)%node)
+            type is (binary_op_node)
+                if (binary_op_is_mixed_precision(ctx, i, props)) then
+                    call push_violation(tmp, violation_count, create_diagnostic( &
+                                        code="P007", &
+                            message="Mixed precision arithmetic can hurt performance", &
+                                        file_path="", &
+                                        location=ctx%get_node_location(i), &
+                                        severity=SEVERITY_INFO))
+                end if
+            end select
+        end do
+    end subroutine analyze_p007
+
+    function binary_op_is_mixed_precision(ctx, node_index, props) result(is_mixed)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        logical :: is_mixed
+
+        integer :: k1, k2
+        character(len=:), allocatable :: op
+        integer :: lidx, ridx
+
+        is_mixed = .false.
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (b => ctx%arena%entries(node_index)%node)
+        type is (binary_op_node)
+            if (.not. allocated(b%operator)) return
+            op = trim(b%operator)
+            if (op /= "+" .and. op /= "-" .and. op /= "*" .and. op /= "/") return
+            lidx = b%left_index
+            ridx = b%right_index
+        class default
+            return
+        end select
+
+        k1 = expr_real_kind(ctx, lidx, props)
+        k2 = expr_real_kind(ctx, ridx, props)
+        if (k1 < 0 .or. k2 < 0) return
+        is_mixed = (k1 /= k2)
+    end function binary_op_is_mixed_precision
+
+    function expr_real_kind(ctx, node_index, props) result(kind_val)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        integer :: kind_val
+
+        character(len=:), allocatable :: name
+
+        kind_val = -1
+        if (node_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (n => ctx%arena%entries(node_index)%node)
+        type is (identifier_node)
+            if (.not. allocated(n%name)) return
+            name = to_lower_ascii(trim(n%name))
+            kind_val = prop_real_kind(props, name)
+        type is (call_or_subscript_node)
+            if (.not. allocated(n%name)) return
+            if (allocated(n%arg_indices)) then
+                if (size(n%arg_indices) > 0) return
+            end if
+            name = to_lower_ascii(trim(n%name))
+            kind_val = prop_real_kind(props, name)
+        type is (literal_node)
+            if (.not. allocated(n%value)) return
+            if (index(n%value, "d") > 0 .or. index(n%value, "D") > 0) then
+                kind_val = 8
+            else
+                kind_val = 0
+            end if
+        end select
+    end function expr_real_kind
+
+    recursive subroutine collect_var_props(ctx, node_index, props)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(inout) :: props(:)
+        integer :: i
+
+        do i = 1, ctx%arena%size
+            if (.not. allocated(ctx%arena%entries(i)%node)) cycle
+            select type (d => ctx%arena%entries(i)%node)
+            type is (declaration_node)
+                call add_decl_props(ctx, i, props)
+            end select
+        end do
+    end subroutine collect_var_props
+
+    recursive function node_has_concat(ctx, node_index) result(found)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical :: found
+        integer :: i
+
+        found = .false.
+        if (node_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (n => ctx%arena%entries(node_index)%node)
+        type is (binary_op_node)
+            if (allocated(n%operator)) then
+                if (trim(n%operator) == "//") then
+                    found = .true.
+                    return
+                end if
+            end if
+            if (node_has_concat(ctx, n%left_index)) then
+                found = .true.
+                return
+            end if
+            if (node_has_concat(ctx, n%right_index)) then
+                found = .true.
+                return
+            end if
+        type is (assignment_node)
+            if (node_has_concat(ctx, n%target_index)) then
+                found = .true.
+                return
+            end if
+            if (node_has_concat(ctx, n%value_index)) then
+                found = .true.
+                return
+            end if
+        type is (call_or_subscript_node)
+            if (allocated(n%arg_indices)) then
+                do i = 1, size(n%arg_indices)
+                    if (node_has_concat(ctx, n%arg_indices(i))) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        type is (do_loop_node)
+            if (allocated(n%body_indices)) then
+                do i = 1, size(n%body_indices)
+                    if (node_has_concat(ctx, n%body_indices(i))) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        end select
+    end function node_has_concat
+
+    recursive function node_has_allocate(ctx, node_index) result(found)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        logical :: found
+        integer :: i
+
+        found = .false.
+        if (node_index <= 0) return
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (n => ctx%arena%entries(node_index)%node)
+        type is (allocate_statement_node)
+            found = .true.
+            return
+        type is (do_loop_node)
+            if (allocated(n%body_indices)) then
+                do i = 1, size(n%body_indices)
+                    if (node_has_allocate(ctx, n%body_indices(i))) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        type is (assignment_node)
+            if (node_has_allocate(ctx, n%target_index)) then
+                found = .true.
+                return
+            end if
+            if (node_has_allocate(ctx, n%value_index)) then
+                found = .true.
+                return
+            end if
+        type is (binary_op_node)
+            if (node_has_allocate(ctx, n%left_index)) then
+                found = .true.
+                return
+            end if
+            if (node_has_allocate(ctx, n%right_index)) then
+                found = .true.
+                return
+            end if
+        type is (call_or_subscript_node)
+            if (allocated(n%arg_indices)) then
+                do i = 1, size(n%arg_indices)
+                    if (node_has_allocate(ctx, n%arg_indices(i))) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            end if
+        end select
+    end function node_has_allocate
+
+    subroutine add_decl_props(ctx, node_index, props)
+        type(fluff_ast_context_t), intent(in) :: ctx
+        integer, intent(in) :: node_index
+        type(var_prop_t), allocatable, intent(inout) :: props(:)
+
+        character(len=:), allocatable :: tname
+        character(len=:), allocatable :: vname
+        integer :: rk
+        integer :: i
+
+        if (.not. allocated(ctx%arena%entries(node_index)%node)) return
+
+        select type (d => ctx%arena%entries(node_index)%node)
+        type is (declaration_node)
+            if (.not. allocated(d%type_name)) return
+            tname = to_lower_ascii(trim(d%type_name))
+            rk = -1
+            if (tname == "real") then
+                if (d%has_kind) then
+                    rk = d%kind_value
+                else
+                    rk = 0
+                end if
+            else if (tname == "double precision" .or. tname == "doubleprecision") then
+                rk = 8
+            else if (index(tname, "real(") == 1) then
+                rk = parse_kind_from_type_name(tname)
+            end if
+            if (d%is_multi_declaration .and. allocated(d%var_names)) then
+                do i = 1, size(d%var_names)
+                    vname = to_lower_ascii(trim(d%var_names(i)))
+                    call upsert_prop(props, vname, d%is_array, rk)
+                end do
+            else if (allocated(d%var_name)) then
+                vname = to_lower_ascii(trim(d%var_name))
+                call upsert_prop(props, vname, d%is_array, rk)
+            end if
+        end select
+    end subroutine add_decl_props
+
+    function parse_kind_from_type_name(type_name) result(kind_val)
+        character(len=*), intent(in) :: type_name
+        integer :: kind_val
+
+        integer :: lpar, rpar, ios
+        character(len=32) :: buf
+
+        kind_val = -1
+        lpar = index(type_name, "(")
+        rpar = index(type_name, ")")
+        if (lpar <= 0 .or. rpar <= lpar) return
+
+        buf = ""
+        if (rpar - lpar - 1 > 0) then
+            buf = type_name(lpar + 1:rpar - 1)
+            read (buf, *, iostat=ios) kind_val
+            if (ios /= 0) kind_val = -1
+        end if
+    end function parse_kind_from_type_name
+
+    subroutine upsert_prop(props, name, is_array, real_kind)
+        type(var_prop_t), allocatable, intent(inout) :: props(:)
+        character(len=*), intent(in) :: name
+        logical, intent(in) :: is_array
+        integer, intent(in) :: real_kind
+
+        integer :: i
+
+        do i = 1, size(props)
+            if (props(i)%name == name) then
+                props(i)%is_array = props(i)%is_array .or. is_array
+                if (real_kind >= 0) props(i)%real_kind = real_kind
+                return
+            end if
+        end do
+
+        props = [props, var_prop_t(name=name, is_array=is_array, real_kind=real_kind)]
+    end subroutine upsert_prop
+
+    function prop_is_array(props, name) result(is_array)
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        character(len=*), intent(in) :: name
+        logical :: is_array
+
+        integer :: i
+
+        is_array = .false.
+        do i = 1, size(props)
+            if (props(i)%name == name) then
+                is_array = props(i)%is_array
+                return
+            end if
+        end do
+    end function prop_is_array
+
+    function prop_real_kind(props, name) result(kind_val)
+        type(var_prop_t), allocatable, intent(in) :: props(:)
+        character(len=*), intent(in) :: name
+        integer :: kind_val
+
+        integer :: i
+
+        kind_val = -1
+        do i = 1, size(props)
+            if (props(i)%name == name) then
+                kind_val = props(i)%real_kind
+                return
+            end if
+        end do
+    end function prop_real_kind
+
+    function has_prefix(prefix_keywords, key) result(found)
+        character(len=16), allocatable, intent(in) :: prefix_keywords(:)
+        character(len=*), intent(in) :: key
+        logical :: found
+
+        integer :: i
+        character(len=:), allocatable :: kw
+
+        found = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            kw = to_lower_ascii(trim(prefix_keywords(i)))
+            if (kw == to_lower_ascii(trim(key))) then
+                found = .true.
+                exit
+            end if
+        end do
+    end function has_prefix
+
+    subroutine push_violation(tmp, count, diag)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: count
+        type(diagnostic_t), intent(in) :: diag
+
+        type(diagnostic_t), allocatable :: grown(:)
+
+        if (count >= size(tmp)) then
+            allocate (grown(max(2*size(tmp), 8)))
+            if (count > 0) grown(1:count) = tmp(1:count)
+            call move_alloc(grown, tmp)
+        end if
+
+        count = count + 1
+        tmp(count) = diag
+    end subroutine push_violation
+
+    pure function to_lower_ascii(s) result(out)
+        character(len=*), intent(in) :: s
+        character(len=len(s)) :: out
+
+        integer :: i, c
+
+        out = s
+        do i = 1, len(s)
+            c = iachar(s(i:i))
+            if (c >= iachar("A") .and. c <= iachar("Z")) then
+                out(i:i) = achar(c + 32)
+            end if
+        end do
+    end function to_lower_ascii
+
+end module fluff_rule_perf

--- a/src/fluff_rules/fluff_rules.f90
+++ b/src/fluff_rules/fluff_rules.f90
@@ -1,15 +1,22 @@
 module fluff_rules
     ! Built-in rule implementations
     use fluff_core
-    use fluff_ast, only: fluff_ast_context_t, NODE_DECLARATION, NODE_IDENTIFIER, &
-                       NODE_FUNCTION_DEF, NODE_SUBROUTINE_DEF, NODE_IF, &
-                       NODE_DO_LOOP, NODE_MODULE, NODE_UNKNOWN, NODE_ASSIGNMENT, &
-                       NODE_PROGRAM
-    use fluff_diagnostics
-    use fluff_rule_types
-    use fortfront, only: symbol_info_t, variable_usage_info_t, get_variables_in_expression, &
-                        SCOPE_FUNCTION, SCOPE_SUBROUTINE, identifier_node, &
-                        semantic_context_t
+	    use fluff_ast, only: fluff_ast_context_t, NODE_DECLARATION, NODE_IDENTIFIER, &
+	                       NODE_FUNCTION_DEF, NODE_SUBROUTINE_DEF, NODE_IF, &
+	                       NODE_DO_LOOP, NODE_MODULE, NODE_UNKNOWN, NODE_ASSIGNMENT, &
+	                       NODE_PROGRAM
+	    use fluff_diagnostics
+	    use fluff_rule_f009, only: check_f009_inconsistent_intent_impl
+	    use fluff_rule_perf, only: check_p002_loop_ordering_impl, &
+	                               check_p003_array_temporaries_impl, &
+	                               check_p004_pure_elemental_impl, &
+	                               check_p005_string_operations_impl, &
+	                               check_p006_loop_allocations_impl, &
+	                               check_p007_mixed_precision_impl
+	    use fluff_rule_types
+	    use fortfront, only: symbol_info_t, variable_usage_info_t, get_variables_in_expression, &
+	                        SCOPE_FUNCTION, SCOPE_SUBROUTINE, identifier_node, &
+	                        semantic_context_t
     use fortfront_compat, only: get_identifier_name, get_symbols_in_scope, &
                                is_identifier_defined_direct, get_unused_variables_direct
     implicit none
@@ -3344,15 +3351,14 @@ contains
     end subroutine check_procedure_arguments_intent
     
     ! F009: Check inconsistent intent usage
-    subroutine check_f009_inconsistent_intent(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! BLOCKED: Requires fortfront AST API (issues #11-14)
-        allocate(violations(0))
-        
-    end subroutine check_f009_inconsistent_intent
+	    subroutine check_f009_inconsistent_intent(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_f009_inconsistent_intent_impl(ctx, node_index, violations)
+
+	    end subroutine check_f009_inconsistent_intent
     
     ! F010: Check obsolete language features
     subroutine check_f010_obsolete_features(ctx, node_index, violations)
@@ -3546,70 +3552,64 @@ contains
     end subroutine check_p001_array_access
     
     ! P002: Check loop ordering efficiency
-    subroutine check_p002_loop_ordering(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! Use fortfront AST to analyze loop ordering
-        call check_p002_loop_ordering_ast_based(ctx, node_index, violations)
-        
-    end subroutine check_p002_loop_ordering
+	    subroutine check_p002_loop_ordering(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p002_loop_ordering_impl(ctx, node_index, violations)
+
+	    end subroutine check_p002_loop_ordering
     
     ! P003: Check array temporaries
-    subroutine check_p003_array_temporaries(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! BLOCKED: Requires fortfront AST API (issues #11-14) array temporaries check
-        allocate(violations(0))
-        
-    end subroutine check_p003_array_temporaries
+	    subroutine check_p003_array_temporaries(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p003_array_temporaries_impl(ctx, node_index, violations)
+
+	    end subroutine check_p003_array_temporaries
     
     ! P004: Check pure/elemental declarations
-    subroutine check_p004_pure_elemental(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! Use fortfront AST to analyze pure/elemental declarations
-        call check_p004_pure_elemental_ast_based(ctx, node_index, violations)
-        
-    end subroutine check_p004_pure_elemental
+	    subroutine check_p004_pure_elemental(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p004_pure_elemental_impl(ctx, node_index, violations)
+
+	    end subroutine check_p004_pure_elemental
     
     ! P005: Check string operations efficiency
-    subroutine check_p005_string_operations(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! BLOCKED: Requires fortfront AST API (issues #11-14) string operations efficiency check
-        allocate(violations(0))
-        
-    end subroutine check_p005_string_operations
+	    subroutine check_p005_string_operations(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p005_string_operations_impl(ctx, node_index, violations)
+
+	    end subroutine check_p005_string_operations
     
     ! P006: Check loop allocations
-    subroutine check_p006_loop_allocations(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! BLOCKED: Requires fortfront AST API (issues #11-14) loop allocations check
-        allocate(violations(0))
-        
-    end subroutine check_p006_loop_allocations
+	    subroutine check_p006_loop_allocations(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p006_loop_allocations_impl(ctx, node_index, violations)
+
+	    end subroutine check_p006_loop_allocations
     
     ! P007: Check mixed precision arithmetic
-    subroutine check_p007_mixed_precision(ctx, node_index, violations)
-        type(fluff_ast_context_t), intent(in) :: ctx
-        integer, intent(in) :: node_index
-        type(diagnostic_t), allocatable, intent(out) :: violations(:)
-        
-        ! BLOCKED: Requires fortfront AST API (issues #11-14) mixed precision arithmetic check
-        allocate(violations(0))
-        
-    end subroutine check_p007_mixed_precision
+	    subroutine check_p007_mixed_precision(ctx, node_index, violations)
+	        type(fluff_ast_context_t), intent(in) :: ctx
+	        integer, intent(in) :: node_index
+	        type(diagnostic_t), allocatable, intent(out) :: violations(:)
+
+	        call check_p007_mixed_precision_impl(ctx, node_index, violations)
+
+	    end subroutine check_p007_mixed_precision
     
     ! C001: Check for undefined variables
     subroutine check_c001_undefined_var(ctx, node_index, violations)

--- a/test/test_rule_p002_loop_ordering.f90
+++ b/test/test_rule_p002_loop_ordering.f90
@@ -5,21 +5,17 @@ program test_rule_p002_loop_ordering
     use fluff_rules
     use fluff_diagnostics
     use fluff_ast
+    use test_support, only: make_temp_fortran_path, write_text_file, &
+                            delete_file_if_exists, assert_has_diagnostic_code
     implicit none
 
     print *, "Testing P002: Inefficient loop ordering rule..."
 
-    ! Test 1: Column-major inefficient ordering
+    ! Test 1: Column-major inefficient ordering (should trigger)
     call test_column_major_inefficient()
 
     ! Test 2: Row-major efficient ordering (should not trigger)
     call test_row_major_efficient()
-
-    ! Test 3: Multi-dimensional array access patterns
-    call test_multidimensional_access()
-
-    ! Test 4: Cache-friendly loop ordering
-    call test_cache_friendly_ordering()
 
     print *, "All P002 tests passed!"
 
@@ -30,44 +26,32 @@ contains
         type(diagnostic_t), allocatable :: diagnostics(:)
         character(len=:), allocatable :: error_msg
         character(len=:), allocatable :: test_code
-        integer :: i
-        logical :: found_p002
+        character(len=:), allocatable :: path
 
-        ! fortfront issue #2612 FIXED: get_children now works
-        ! P002 rule enabled and running - nested loop detection depends on AST structure
-        ! Rule reports on any nested loop structure as a heuristic suggestion
-        test_code = "program test" // new_line('a') // &
-                   "    implicit none" // new_line('a') // &
-                   "    integer, parameter :: n = 1000, m = 1000" // new_line('a') // &
-                   "    real :: matrix(n, m)" // new_line('a') // &
-                   "    integer :: i, j" // new_line('a') // &
-                   "    " // new_line('a') // &
-                   "    ! Inefficient: accessing by rows in column-major Fortran" // new_line('a') // &
-                   "    do i = 1, n" // new_line('a') // &
-                   "        do j = 1, m" // new_line('a') // &
-                   "            matrix(i, j) = real(i * j)" // new_line('a') // &
-                   "        end do" // new_line('a') // &
-                   "    end do" // new_line('a') // &
-                   "end program test"
+        test_code = "program test"//new_line('a')// &
+                    "    implicit none"//new_line('a')// &
+                    "    integer, parameter :: n = 10, m = 10"//new_line('a')// &
+                    "    real :: matrix(n, m)"//new_line('a')// &
+                    "    integer :: i, j"//new_line('a')// &
+                    "    "//new_line('a')// &
+       "    ! Inefficient: accessing by rows in column-major Fortran"//new_line('a')// &
+                    "    do i = 1, n"//new_line('a')// &
+                    "        do j = 1, m"//new_line('a')// &
+                    "            matrix(i, j) = real(i * j)"//new_line('a')// &
+                    "        end do"//new_line('a')// &
+                    "    end do"//new_line('a')// &
+                    "end program test"
 
         linter = create_linter_engine()
 
-        ! Create temporary file
-        open(unit=99, file="test_p002.f90", status="replace")
-        write(99, '(A)') test_code
-        close(99)
+        call make_temp_fortran_path("fluff_test_p002_bad", path)
+        call write_text_file(path, test_code)
+        call linter%lint_file(path, diagnostics, error_msg)
+        call delete_file_if_exists(path)
 
-        ! Lint the file
-        call linter%lint_file("test_p002.f90", diagnostics, error_msg)
-
-        ! Clean up
-        open(unit=99, file="test_p002.f90", status="old")
-        close(99, status="delete")
-
-        ! P002 rule is enabled (issue #2612 fixed) - check if any diagnostics produced
-        ! The rule runs as a heuristic on nested loops; actual violation detection
-        ! may depend on AST structure specifics
-        print *, "  + Column-major loop ordering (rule enabled, analyzing nested loops)"
+        call assert_has_diagnostic_code(diagnostics, "P002", .true., &
+                                        "inefficient loop ordering should be flagged")
+        print *, "  + Column-major inefficient ordering"
 
     end subroutine test_column_major_inefficient
 
@@ -76,51 +60,33 @@ contains
         type(diagnostic_t), allocatable :: diagnostics(:)
         character(len=:), allocatable :: error_msg
         character(len=:), allocatable :: test_code
-        integer :: i
-        logical :: found_p002
+        character(len=:), allocatable :: path
 
-        ! fortfront issue #2612 FIXED: get_children now works
-        test_code = "program test" // new_line('a') // &
-                   "    implicit none" // new_line('a') // &
-                   "    integer, parameter :: n = 1000, m = 1000" // new_line('a') // &
-                   "    real :: matrix(n, m)" // new_line('a') // &
-                   "    integer :: i, j" // new_line('a') // &
-                   "    " // new_line('a') // &
-                   "    ! Efficient: accessing by columns in column-major Fortran" // new_line('a') // &
-                   "    do j = 1, m" // new_line('a') // &
-                   "        do i = 1, n" // new_line('a') // &
-                   "            matrix(i, j) = real(i * j)" // new_line('a') // &
-                   "        end do" // new_line('a') // &
-                   "    end do" // new_line('a') // &
-                   "end program test"
+        test_code = "program test"//new_line('a')// &
+                    "    implicit none"//new_line('a')// &
+                    "    integer, parameter :: n = 10, m = 10"//new_line('a')// &
+                    "    real :: matrix(n, m)"//new_line('a')// &
+                    "    integer :: i, j"//new_line('a')// &
+                    "    "//new_line('a')// &
+      "    ! Efficient: accessing by columns in column-major Fortran"//new_line('a')// &
+                    "    do j = 1, m"//new_line('a')// &
+                    "        do i = 1, n"//new_line('a')// &
+                    "            matrix(i, j) = real(i * j)"//new_line('a')// &
+                    "        end do"//new_line('a')// &
+                    "    end do"//new_line('a')// &
+                    "end program test"
 
         linter = create_linter_engine()
 
-        ! Create temporary file
-        open(unit=99, file="test_p002_ok.f90", status="replace")
-        write(99, '(A)') test_code
-        close(99)
+        call make_temp_fortran_path("fluff_test_p002_ok", path)
+        call write_text_file(path, test_code)
+        call linter%lint_file(path, diagnostics, error_msg)
+        call delete_file_if_exists(path)
 
-        ! Lint the file
-        call linter%lint_file("test_p002_ok.f90", diagnostics, error_msg)
-
-        ! Clean up
-        open(unit=99, file="test_p002_ok.f90", status="old")
-        close(99, status="delete")
-
-        ! P002 rule is enabled (issue #2612 fixed)
-        print *, "  + Row-major loop ordering (rule enabled)"
+        call assert_has_diagnostic_code(diagnostics, "P002", .false., &
+                                        "efficient loop ordering should not be flagged")
+        print *, "  + Row-major efficient ordering"
 
     end subroutine test_row_major_efficient
-
-    subroutine test_multidimensional_access()
-        ! fortfront issue #2612 FIXED: get_children now works
-        print *, "  + Multi-dimensional array access (rule enabled)"
-    end subroutine test_multidimensional_access
-
-    subroutine test_cache_friendly_ordering()
-        ! fortfront issue #2612 FIXED: get_children now works
-        print *, "  + Cache-friendly loop ordering (rule enabled)"
-    end subroutine test_cache_friendly_ordering
 
 end program test_rule_p002_loop_ordering

--- a/test/test_rule_p005_string_operations.f90
+++ b/test/test_rule_p005_string_operations.f90
@@ -5,45 +5,73 @@ program test_rule_p005_string_operations
     use fluff_rules
     use fluff_diagnostics
     use fluff_ast
+    use test_support, only: make_temp_fortran_path, write_text_file, &
+                            delete_file_if_exists, assert_has_diagnostic_code
     implicit none
 
     print *, "Testing P005: Inefficient string operations rule..."
 
-    ! Test 1: Inefficient string concatenation (should trigger)
-    call test_inefficient_concatenation()
-
-    ! Test 2: Efficient string operations (should not trigger)
-    call test_efficient_operations()
-
-    ! Test 3: String operations in loops
-    call test_string_operations_in_loops()
-
-    ! Test 4: Repeated string allocations
-    call test_repeated_allocations()
+    call test_loop_concatenation_triggers()
+    call test_no_concatenation_is_ok()
 
     print *, "All P005 tests passed!"
 
 contains
 
-    subroutine test_inefficient_concatenation()
-        ! P005 implementation enabled - needs string expression analysis from fortfront
-        ! get_children() now works (issue #2612), but still needs string type analysis
-        print *, "  + Inefficient string concatenation (rule enabled, needs string analysis)"
-    end subroutine test_inefficient_concatenation
+    subroutine test_loop_concatenation_triggers()
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: test_code
+        character(len=:), allocatable :: path
 
-    subroutine test_efficient_operations()
-        ! P005 implementation enabled - tests that efficient string ops are not flagged
-        print *, "  + Efficient string operations (rule enabled)"
-    end subroutine test_efficient_operations
+        test_code = "program test"//new_line('a')// &
+                    "implicit none"//new_line('a')// &
+                    "integer :: i"//new_line('a')// &
+                    "character(len=:), allocatable :: s"//new_line('a')// &
+                    "s = ''"//new_line('a')// &
+                    "do i = 1, 10"//new_line('a')// &
+                    "    s = s // 'a'"//new_line('a')// &
+                    "end do"//new_line('a')// &
+                    "end program test"
 
-    subroutine test_string_operations_in_loops()
-        ! P005 enabled - placeholder for loop string operation tests
-        print *, "  + String operations in loops (rule enabled)"
-    end subroutine test_string_operations_in_loops
+        linter = create_linter_engine()
+        call make_temp_fortran_path("fluff_test_p005_bad", path)
+        call write_text_file(path, test_code)
+        call linter%lint_file(path, diagnostics, error_msg)
+        call delete_file_if_exists(path)
 
-    subroutine test_repeated_allocations()
-        ! P005 enabled - placeholder for repeated allocation tests
-        print *, "  + Repeated string allocations (rule enabled)"
-    end subroutine test_repeated_allocations
+        call assert_has_diagnostic_code(diagnostics, "P005", .true., &
+                                       "string concatenation in loop should be flagged")
+        print *, "  + Loop concatenation"
+    end subroutine test_loop_concatenation_triggers
+
+    subroutine test_no_concatenation_is_ok()
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: test_code
+        character(len=:), allocatable :: path
+
+        test_code = "program test"//new_line('a')// &
+                    "implicit none"//new_line('a')// &
+                    "integer :: i"//new_line('a')// &
+                    "character(len=10) :: s"//new_line('a')// &
+                    "s = ''"//new_line('a')// &
+                    "do i = 1, 10"//new_line('a')// &
+                    "    s(i:i) = 'a'"//new_line('a')// &
+                    "end do"//new_line('a')// &
+                    "end program test"
+
+        linter = create_linter_engine()
+        call make_temp_fortran_path("fluff_test_p005_ok", path)
+        call write_text_file(path, test_code)
+        call linter%lint_file(path, diagnostics, error_msg)
+        call delete_file_if_exists(path)
+
+        call assert_has_diagnostic_code(diagnostics, "P005", .false., &
+                                        "no concatenation should not be flagged")
+        print *, "  + No concatenation"
+    end subroutine test_no_concatenation_is_ok
 
 end program test_rule_p005_string_operations

--- a/test/test_support.f90
+++ b/test/test_support.f90
@@ -1,0 +1,89 @@
+module test_support
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fluff_diagnostics, only: diagnostic_t
+    implicit none
+    private
+
+    public :: make_temp_fortran_path
+    public :: write_text_file
+    public :: delete_file_if_exists
+    public :: assert_has_diagnostic_code
+
+contains
+
+    subroutine make_temp_fortran_path(stem, path)
+        character(len=*), intent(in) :: stem
+        character(len=:), allocatable, intent(out) :: path
+
+        integer :: values(8)
+        character(len=128) :: name
+
+        call date_and_time(values=values)
+        write (name, '(A,"_",I4.4,I2.2,I2.2,"_",I2.2,I2.2,I2.2,"_",I3.3)') &
+            trim(stem), values(1), values(2), values(3), values(5), values(6), &
+            values(7), values(8)
+        path = "/tmp/"//trim(name)//".f90"
+    end subroutine make_temp_fortran_path
+
+    subroutine write_text_file(path, text)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: text
+
+        integer :: unit
+
+        open (newunit=unit, file=path, status="replace", action="write")
+        write (unit, '(A)') text
+        close (unit)
+    end subroutine write_text_file
+
+    subroutine delete_file_if_exists(path)
+        character(len=*), intent(in) :: path
+
+        integer :: unit, ios
+
+        open (newunit=unit, file=path, status="old", action="read", iostat=ios)
+        if (ios == 0) then
+            close (unit, status="delete")
+        end if
+    end subroutine delete_file_if_exists
+
+    subroutine assert_has_diagnostic_code(diags, code, expected, message)
+        type(diagnostic_t), allocatable, intent(in) :: diags(:)
+        character(len=*), intent(in) :: code
+        logical, intent(in) :: expected
+        character(len=*), intent(in) :: message
+
+        integer :: i
+        logical :: found
+
+        found = .false.
+        if (allocated(diags)) then
+            do i = 1, size(diags)
+                if (diags(i)%code == code) then
+                    found = .true.
+                    exit
+                end if
+            end do
+        end if
+
+        if (found .neqv. expected) then
+            if (allocated(diags)) then
+                do i = 1, size(diags)
+                    write (error_unit, '(A,1X,A,1X,A,1X,A)') &
+                        "diagnostic:", diags(i)%code, "-", trim(diags(i)%message)
+                end do
+            else
+                write (error_unit, '(A)') "diagnostic: <none>"
+            end if
+            flush (error_unit)
+            if (expected) then
+                error stop "Failed: expected diagnostic "//trim(code)// &
+                    " not found: "//trim(message)
+            else
+                error stop "Failed: unexpected diagnostic "//trim(code)// &
+                    " found: "//trim(message)
+            end if
+        end if
+    end subroutine assert_has_diagnostic_code
+
+end module test_support


### PR DESCRIPTION
## Summary

This PR restores strict, behavioral tests (no print-only placeholders) and provides real implementations for:

- F009: inconsistent intent usage
- P002-P007: performance rules (minimal heuristics to make tests meaningful)

It also adds a small test helper to write temporary Fortran sources under `/tmp`.

## Testing

- `fpm test 2>&1 | tee /tmp/fluff_fpm_test_restore_pr98.log`
