### PR TITLE
fix: Expose missing fortfront APIs in fluff_ast wrapper (fixes #79)

### DIFF
--- a/src/fluff_ast/fluff_ast.f90
+++ b/src/fluff_ast/fluff_ast.f90
@@ -305,8 +305,8 @@ contains
         character(len=*), intent(in) :: name
         type(symbol_info_t) :: info
 
+        info = symbol_info_t()
         info%name = name
-        info%is_defined = .false.
         if (.not. this%is_initialized) return
 
         info = lookup_symbol(this%semantic_ctx%scopes, name)

--- a/test/test_fluff_ast_wrapper_api.f90
+++ b/test/test_fluff_ast_wrapper_api.f90
@@ -1,8 +1,7 @@
 program test_fluff_ast_wrapper_api
     use fluff_ast, only: create_ast_context, fluff_ast_context_t, fluff_trivia_t, &
                          NODE_ASSIGNMENT
-    use fortfront, only: CST_COMMENT, CST_NEWLINE, CST_WHITESPACE
-    use fortfront, only: symbol_info_t
+    use fortfront, only: CST_COMMENT, CST_NEWLINE, CST_WHITESPACE, symbol_info_t
     implicit none
 
     logical :: all_passed


### PR DESCRIPTION
## Summary
- Expose fortfront source text, CST trivia, symbol table, and variable-usage query APIs via `src/fluff_ast/fluff_ast.f90`.
- Add coverage proving AST traversal, trivia queries, source retrieval, and symbol queries work end-to-end.

## Verification
- `fpm test 2>&1 | tee /tmp/fpm-test.log`

Output excerpt:
```
Project is up to date
All LSP diagnostic tests passed!
STOP 0
```

## Notes
- New test: `test/test_fluff_ast_wrapper_api.f90`.
- `test/test_lsp_diagnostics.f90` now writes its temporary file under `/tmp` and enforces a 100% pass rate.
