### PR TITLE
fix: polish: deduplicate visual-column calculation for tabs (fixes #131)

### DIFF
--- a/src/fluff_rules/style/fluff_rule_f003.f90
+++ b/src/fluff_rules/style/fluff_rule_f003.f90
@@ -7,6 +7,7 @@ module fluff_rule_f003
     private
 
     public :: check_f003_line_length
+    public :: f003_visual_columns
 
 contains
 
@@ -36,7 +37,7 @@ contains
             call ctx%get_source_line(line_num, line_text, found)
             if (.not. found) exit
 
-            line_length = physical_line_length(line_text)
+            line_length = f003_visual_columns(line_text)
             if (line_length > max_length) then
                 if (.not. is_comment_only_line(line_text)) then
                     violation_count = violation_count + 1
@@ -57,7 +58,7 @@ contains
             call ctx%get_source_line(line_num, line_text, found)
             if (.not. found) exit
 
-            line_length = physical_line_length(line_text)
+            line_length = f003_visual_columns(line_text)
             if (line_length > max_length) then
                 if (.not. is_comment_only_line(line_text)) then
                     violation_count = violation_count + 1
@@ -93,7 +94,7 @@ contains
                severity=SEVERITY_WARNING)
     end function create_f003_diagnostic
 
-    integer function physical_line_length(line_text) result(length)
+    integer function f003_visual_columns(line_text) result(cols)
         character(len=*), intent(in) :: line_text
         integer, parameter :: tab_width = 4
         integer :: i, col, next_stop
@@ -113,8 +114,8 @@ contains
             end select
         end do
 
-        length = col
-    end function physical_line_length
+        cols = col
+    end function f003_visual_columns
 
     logical function is_comment_only_line(line_text) result(is_comment)
         character(len=*), intent(in) :: line_text

--- a/test/test_rule_f003_line_length.f90
+++ b/test/test_rule_f003_line_length.f90
@@ -3,6 +3,7 @@ program test_rule_f003_line_length
     use fluff_config, only: create_default_config, fluff_config_t
     use fluff_diagnostics, only: diagnostic_t
     use fluff_linter, only: create_linter_engine, linter_engine_t
+    use fluff_rule_f003, only: f003_visual_columns
     implicit none
 
     print *, "Testing F003: Line too long rule..."
@@ -317,7 +318,7 @@ contains
         logical :: found_f003, found_location
 
         long_line = achar(9)//"real :: x = 0.0 ! "//repeat("a", 90)
-        expected_end_col = visual_columns(long_line)
+        expected_end_col = f003_visual_columns(long_line)
 
         test_code = "program test"//new_line('a')// &
                     "    implicit none"//new_line('a')// &
@@ -363,26 +364,5 @@ contains
 
         print *, "  ✓ Tabs counted as visual columns"
     end subroutine test_tabs_column_calculation
-
-    integer function visual_columns(line_text) result(cols)
-        character(len=*), intent(in) :: line_text
-        integer, parameter :: tab_width = 4
-        integer :: i, col, next_stop
-        character(len=1) :: ch
-
-        col = 0
-        do i = 1, len(line_text)
-            ch = line_text(i:i)
-            if (i == len(line_text) .and. ch == achar(13)) exit
-            select case (ch)
-            case (achar(9))
-                next_stop = ((col/tab_width) + 1)*tab_width
-                col = next_stop
-            case default
-                col = col + 1
-            end select
-        end do
-        cols = col
-    end function visual_columns
 
 end program test_rule_f003_line_length


### PR DESCRIPTION
Summary:
- Deduplicate F003 tab-stop visual column calculation by exporting `f003_visual_columns` from `fluff_rule_f003` and reusing it in the F003 test.

Verification:
- fpm test 2>&1 | tee /tmp/fluff_fpm_test_issue131.log
- Excerpts from /tmp/fluff_fpm_test_issue131.log:
  - All F003 tests passed!
  - STOP 0
