### PR TITLE
fix: deduplicate trivia scanning helpers used by F004/F005 (fixes #137)

### DIFF
--- a/src/fluff_rules/shared/fluff_rule_trivia_utils.f90
+++ b/src/fluff_rules/shared/fluff_rule_trivia_utils.f90
@@ -1,0 +1,72 @@
+module fluff_rule_trivia_utils
+    use fluff_core, only: source_range_t
+    implicit none
+    private
+
+    public :: location_buffer_t
+    public :: location_buffer_init
+    public :: location_buffer_push
+    public :: location_buffer_finish
+    public :: text_has_space_and_tab
+
+    type :: location_buffer_t
+        type(source_range_t), allocatable :: data(:)
+        integer :: n = 0
+    end type location_buffer_t
+
+contains
+
+    subroutine location_buffer_init(buf)
+        type(location_buffer_t), intent(inout) :: buf
+
+        buf%n = 0
+        if (allocated(buf%data)) deallocate (buf%data)
+        allocate (buf%data(8))
+    end subroutine location_buffer_init
+
+    subroutine location_buffer_push(buf, location)
+        type(location_buffer_t), intent(inout) :: buf
+        type(source_range_t), intent(in) :: location
+
+        type(source_range_t), allocatable :: tmp(:)
+        integer :: capacity, new_capacity
+
+        if (.not. allocated(buf%data)) then
+            allocate (buf%data(8))
+            buf%n = 0
+        end if
+
+        capacity = size(buf%data)
+        if (buf%n >= capacity) then
+            new_capacity = max(1, 2*capacity)
+            allocate (tmp(new_capacity))
+            if (buf%n > 0) tmp(1:buf%n) = buf%data(1:buf%n)
+            call move_alloc(tmp, buf%data)
+        end if
+
+        buf%n = buf%n + 1
+        buf%data(buf%n) = location
+    end subroutine location_buffer_push
+
+    subroutine location_buffer_finish(buf, locations)
+        type(location_buffer_t), intent(inout) :: buf
+        type(source_range_t), allocatable, intent(out) :: locations(:)
+
+        if (buf%n <= 0) then
+            allocate (locations(0))
+        else
+            allocate (locations(buf%n))
+            locations = buf%data(1:buf%n)
+        end if
+
+        if (allocated(buf%data)) deallocate (buf%data)
+        buf%n = 0
+    end subroutine location_buffer_finish
+
+    pure logical function text_has_space_and_tab(text) result(has_both)
+        character(len=*), intent(in) :: text
+
+        has_both = (index(text, " ") > 0 .and. index(text, achar(9)) > 0)
+    end function text_has_space_and_tab
+
+end module fluff_rule_trivia_utils

--- a/src/fluff_rules/style/fluff_rule_f005.f90
+++ b/src/fluff_rules/style/fluff_rule_f005.f90
@@ -3,6 +3,9 @@ module fluff_rule_f005
     use fluff_core, only: source_range_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_rule_file_context, only: current_filename, current_source_text
+    use fluff_rule_trivia_utils, only: location_buffer_t, location_buffer_init, &
+                                       location_buffer_push, location_buffer_finish, &
+                                       text_has_space_and_tab
     use fortfront, only: token_t, tokenize_core_with_trivia, trivia_token_t
     use lexer_token_types, only: TK_WHITESPACE
     implicit none
@@ -48,20 +51,29 @@ contains
     subroutine collect_mixed_indentation(tokens, locations)
         type(token_t), allocatable, intent(in) :: tokens(:)
         type(source_range_t), allocatable, intent(out) :: locations(:)
+
+        type(location_buffer_t) :: buffer
         integer :: i
 
-        allocate (locations(0))
-        if (.not. allocated(tokens)) return
-        if (size(tokens) <= 0) return
+        call location_buffer_init(buffer)
+        if (.not. allocated(tokens)) then
+            call location_buffer_finish(buffer, locations)
+            return
+        end if
+        if (size(tokens) <= 0) then
+            call location_buffer_finish(buffer, locations)
+            return
+        end if
 
         do i = 1, size(tokens)
-            call collect_from_trivia(tokens(i)%leading_trivia, locations)
+            call collect_from_trivia(tokens(i)%leading_trivia, buffer)
         end do
+        call location_buffer_finish(buffer, locations)
     end subroutine collect_mixed_indentation
 
-    subroutine collect_from_trivia(trivia, locations)
+    subroutine collect_from_trivia(trivia, buffer)
         type(trivia_token_t), allocatable, intent(in) :: trivia(:)
-        type(source_range_t), allocatable, intent(inout) :: locations(:)
+        type(location_buffer_t), intent(inout) :: buffer
 
         integer :: i
         integer :: end_col
@@ -74,40 +86,15 @@ contains
             if (trivia(i)%kind /= TK_WHITESPACE) cycle
             if (trivia(i)%column /= 1) cycle
             if (.not. allocated(trivia(i)%text)) cycle
-            if (.not. has_space_and_tab(trivia(i)%text)) cycle
+            if (.not. text_has_space_and_tab(trivia(i)%text)) cycle
 
             end_col = trivia(i)%column + len(trivia(i)%text) - 1
             location%start%line = trivia(i)%line
             location%start%column = trivia(i)%column
             location%end%line = trivia(i)%line
             location%end%column = end_col
-            call append_location(locations, location)
+            call location_buffer_push(buffer, location)
         end do
     end subroutine collect_from_trivia
-
-    logical function has_space_and_tab(text) result(has_both)
-        character(len=*), intent(in) :: text
-
-        has_both = (index(text, " ") > 0 .and. index(text, achar(9)) > 0)
-    end function has_space_and_tab
-
-    subroutine append_location(locations, location)
-        type(source_range_t), allocatable, intent(inout) :: locations(:)
-        type(source_range_t), intent(in) :: location
-        type(source_range_t), allocatable :: tmp(:)
-        integer :: n
-
-        if (.not. allocated(locations)) then
-            allocate (locations(1))
-            locations(1) = location
-            return
-        end if
-
-        n = size(locations)
-        allocate (tmp(n + 1))
-        if (n > 0) tmp(1:n) = locations
-        tmp(n + 1) = location
-        call move_alloc(tmp, locations)
-    end subroutine append_location
 
 end module fluff_rule_f005


### PR DESCRIPTION
Fixes #137
Fixes #136

## Summary
- Added `fluff_rule_trivia_utils` with a small `location_buffer_t` to share trivia location collection between F004/F005.
- Updated F004/F005 to use the shared buffer (removes per-append reallocations) and centralized the mixed whitespace predicate.

## Verification
- `fpm test 2>&1 | tee /tmp/fluff-fpm-test.log`

Output excerpt:
- `All F005 tests passed!`
- `All F004 tests passed!`
- `STOP 0`
