### PR TITLE
fix: polish: unify visual_columns test assertions (fixes #142)

### DIFF
--- a/test/test_support.f90
+++ b/test/test_support.f90
@@ -9,6 +9,7 @@ module test_support
     public :: delete_file_if_exists
     public :: assert_has_diagnostic_code
     public :: assert_diagnostic_location
+    public :: assert_equal_int
 
 contains
 
@@ -119,5 +120,19 @@ contains
             call assert_has_diagnostic_code(diags, code, .true., message)
         end if
     end subroutine assert_diagnostic_location
+
+    subroutine assert_equal_int(actual, expected, context)
+        integer, intent(in) :: actual
+        integer, intent(in) :: expected
+        character(len=*), intent(in) :: context
+
+        if (actual /= expected) then
+            write (error_unit, '(A)') "Failed: "//trim(context)
+            write (error_unit, '(A,I0)') "  expected: ", expected
+            write (error_unit, '(A,I0)') "  actual:   ", actual
+            flush (error_unit)
+            error stop 1
+        end if
+    end subroutine assert_equal_int
 
 end module test_support

--- a/test/test_visual_columns.f90
+++ b/test/test_visual_columns.f90
@@ -1,5 +1,6 @@
 program test_visual_columns
     use fluff_visual_columns, only: visual_columns
+    use test_support, only: assert_equal_int
     implicit none
 
     call assert_equal_int(visual_columns(achar(9)//"x"), 5, "default tab width")
@@ -14,17 +15,5 @@ program test_visual_columns
                           "tab stop after two chars")
     call assert_equal_int(visual_columns("ab"//achar(9)//"c", tab_width=8), 9, &
                           "tab stop after two chars with width 8")
-
-contains
-
-    subroutine assert_equal_int(actual, expected, context)
-        integer, intent(in) :: actual
-        integer, intent(in) :: expected
-        character(len=*), intent(in) :: context
-
-        if (actual /= expected) then
-            error stop "Failed: "//trim(context)
-        end if
-    end subroutine assert_equal_int
 
 end program test_visual_columns


### PR DESCRIPTION
Fixes #142

- Reuse shared `assert_equal_int` from `test/test_support.f90`.
- Improve `test/test_visual_columns.f90` failures to include expected/actual values.

## Verification

`fpm test 2>&1 | tee /tmp/fluff-fpm-test-issue-142.log`

Excerpt from `/tmp/fluff-fpm-test-issue-142.log`:

```
[ 48%]        test_visual_columns.f90
[ 51%]        test_visual_columns.f90  done.
[100%] Project compiled successfully.
```
