### PR TITLE
fix: standardize ASCII markers in test output (fixes #173)

### DIFF
--- a/test/test_ast_cache.f90
+++ b/test/test_ast_cache.f90
@@ -19,7 +19,7 @@ program test_ast_cache
     ! Test 4: Content hash verification
     call test_content_hash()
     
-    print *, "All AST cache tests passed!"
+    print *, "[OK] All AST cache tests passed!"
     
 contains
     
@@ -59,7 +59,7 @@ contains
             error stop "Failed: should not match different content"
         end if
         
-        print *, "  OK Basic cache operations"
+        print *, "[OK] Basic cache operations"
         
     end subroutine test_cache_operations
     
@@ -95,7 +95,7 @@ contains
             error stop "Failed: cache should be cleared"
         end if
         
-        print *, "  OK Cache invalidation"
+        print *, "[OK] Cache invalidation"
         
     end subroutine test_cache_invalidation
     
@@ -122,7 +122,7 @@ contains
             error stop "Failed: cache exceeded max capacity"
         end if
         
-        print *, "  OK Cache capacity and eviction"
+        print *, "[OK] Cache capacity and eviction"
         
     end subroutine test_cache_eviction
     
@@ -147,7 +147,7 @@ contains
             error stop "Failed: different content should have different hash"
         end if
         
-        print *, "  OK Content hash verification"
+        print *, "[OK] Content hash verification"
         
     end subroutine test_content_hash
     

--- a/test/test_ast_debug.f90
+++ b/test/test_ast_debug.f90
@@ -76,7 +76,7 @@ program test_ast_debug
     
     ! Explore all nodes in arena
     print *, ""
-    print *, "All nodes in arena:"
+    print *, "[OK] All nodes in arena:"
     do i = 1, arena%size
         print *, "  Index", i, "type:", get_node_type(arena, i), "parent:", get_parent(arena, i)
 

--- a/test/test_cache_integration.f90
+++ b/test/test_cache_integration.f90
@@ -14,7 +14,7 @@ program test_cache_integration
     ! Test 2: Cache invalidation on file change
     call test_cache_invalidation()
     
-    print *, "All cache integration tests passed!"
+    print *, "[OK] All cache integration tests passed!"
     
 contains
     
@@ -31,7 +31,7 @@ contains
         ! Note: We can't actually test performance without fortfront
         ! but we can verify the cache is being used
         
-        print *, "  OK Cache performance (structure verified)"
+        print *, "[OK] Cache performance (structure verified)"
         
     end subroutine test_cache_performance
     
@@ -46,7 +46,7 @@ contains
         ! Test that cache can be cleared
         call linter%ast_cache%clear()
         
-        print *, "  OK Cache invalidation"
+        print *, "[OK] Cache invalidation"
         
     end subroutine test_cache_invalidation
     

--- a/test/test_clean_architecture.f90
+++ b/test/test_clean_architecture.f90
@@ -24,7 +24,7 @@ program test_clean_architecture
     ! Test 4: Proper error handling exists
     call test_error_handling()
     
-    print *, "All clean architecture tests passed!"
+    print *, "[OK] All clean architecture tests passed!"
     
 contains
     
@@ -40,7 +40,7 @@ contains
             error stop "Failed: Version should be 0.1.0"
         end if
         
-        print *, "  OK Core module is independent"
+        print *, "[OK] Core module is independent"
     end subroutine test_core_independence
     
     subroutine test_ast_dependencies()
@@ -53,7 +53,7 @@ contains
             error stop "Failed: AST context should not be initialized by default"
         end if
         
-        print *, "  OK AST module has clean dependencies"
+        print *, "[OK] AST module has clean dependencies"
     end subroutine test_ast_dependencies
     
     subroutine test_diagnostics_dependencies()
@@ -80,7 +80,7 @@ contains
             error stop "Failed: Diagnostic should produce string representation"
         end if
         
-        print *, "  OK Diagnostics module has clean dependencies"
+        print *, "[OK] Diagnostics module has clean dependencies"
     end subroutine test_diagnostics_dependencies
     
     subroutine test_error_handling()
@@ -103,7 +103,7 @@ contains
             error stop "Failed: Error message not preserved"
         end if
         
-        print *, "  OK Error handling is consistent"
+        print *, "[OK] Error handling is consistent"
     end subroutine test_error_handling
     
 end program test_clean_architecture

--- a/test/test_cli_argument_parsing.f90
+++ b/test/test_cli_argument_parsing.f90
@@ -23,7 +23,7 @@ program test_cli_argument_parsing
     ! Test 5: Parse output format
     call test_output_format()
     
-    print *, "All CLI argument parsing tests passed!"
+    print *, "[OK] All CLI argument parsing tests passed!"
     
 contains
     
@@ -52,7 +52,7 @@ contains
             error stop "Failed: file should be 'test.f90'"
         end if
         
-        print *, "  OK Basic check command parsing"
+        print *, "[OK] Basic check command parsing"
         
     end subroutine test_basic_check_command
     
@@ -79,7 +79,7 @@ contains
             error stop "Failed: fix should be true"
         end if
         
-        print *, "  OK Format command with options"
+        print *, "[OK] Format command with options"
         
     end subroutine test_format_command_with_options
     
@@ -104,7 +104,7 @@ contains
             error stop "Failed: incorrect files parsed"
         end if
         
-        print *, "  OK Multiple files parsing"
+        print *, "[OK] Multiple files parsing"
         
     end subroutine test_multiple_files
     
@@ -123,7 +123,7 @@ contains
             error stop "Failed: config file should be 'fluff.toml'"
         end if
         
-        print *, "  OK Config file option parsing"
+        print *, "[OK] Config file option parsing"
         
     end subroutine test_config_file_option
     
@@ -142,7 +142,7 @@ contains
             error stop "Failed: output format should be 'json'"
         end if
         
-        print *, "  OK Output format parsing"
+        print *, "[OK] Output format parsing"
         
     end subroutine test_output_format
     

--- a/test/test_cli_override.f90
+++ b/test/test_cli_override.f90
@@ -15,7 +15,7 @@ program test_cli_override
     ! Test 3: Priority order
     call test_priority_order()
     
-    print *, "All CLI override tests passed!"
+    print *, "[OK] All CLI override tests passed!"
     
 contains
     
@@ -50,7 +50,7 @@ contains
             error stop "Failed: line_length should remain from file when not in CLI"
         end if
         
-        print *, "  OK CLI overrides file configuration"
+        print *, "[OK] CLI overrides file configuration"
     end subroutine test_cli_overrides_file
     
     subroutine test_config_merge()
@@ -99,7 +99,7 @@ contains
             error stop "Failed: ignore rules should be added"
         end if
         
-        print *, "  OK Configuration merge"
+        print *, "[OK] Configuration merge"
     end subroutine test_config_merge
     
     subroutine test_priority_order()
@@ -127,7 +127,7 @@ contains
             error stop "Failed: File config should override defaults"
         end if
         
-        print *, "  OK Configuration priority order"
+        print *, "[OK] Configuration priority order"
     end subroutine test_priority_order
     
 end program test_cli_override

--- a/test/test_cli_subcommands.f90
+++ b/test/test_cli_subcommands.f90
@@ -22,7 +22,7 @@ program test_cli_subcommands
     ! Test 5: Version flag handling
     call test_version_flag()
     
-    print *, "All CLI subcommand tests passed!"
+    print *, "[OK] All CLI subcommand tests passed!"
     
 contains
     
@@ -43,7 +43,7 @@ contains
             error stop "Failed: linter should be initialized"
         end if
         
-        print *, "  OK Check command initialization"
+        print *, "[OK] Check command initialization"
         
     end subroutine test_check_command_init
     
@@ -63,7 +63,7 @@ contains
             error stop "Failed: formatter should be initialized"
         end if
         
-        print *, "  OK Format command initialization"
+        print *, "[OK] Format command initialization"
         
     end subroutine test_format_command_init
     
@@ -85,7 +85,7 @@ contains
         ! Server command should fail for now (not implemented)
         ! We just verify it's recognized
         
-        print *, "  OK Server command recognized"
+        print *, "[OK] Server command recognized"
         
     end subroutine test_server_command
     
@@ -103,7 +103,7 @@ contains
             error stop "Failed: help flag should be true"
         end if
         
-        print *, "  OK Help flag handling"
+        print *, "[OK] Help flag handling"
         
     end subroutine test_help_flag
     
@@ -121,7 +121,7 @@ contains
             error stop "Failed: version flag should be true"
         end if
         
-        print *, "  OK Version flag handling"
+        print *, "[OK] Version flag handling"
         
     end subroutine test_version_flag
     

--- a/test/test_config_schema.f90
+++ b/test/test_config_schema.f90
@@ -17,7 +17,7 @@ program test_config_schema
     ! Test 4: Schema documentation
     call test_schema_documentation()
     
-    print *, "All configuration schema tests passed!"
+    print *, "[OK] All configuration schema tests passed!"
     
 contains
     
@@ -57,7 +57,7 @@ contains
             error stop "Failed: error should mention the invalid rule code"
         end if
         
-        print *, "  OK Comprehensive validation messages"
+        print *, "[OK] Comprehensive validation messages"
     end subroutine test_validation_messages
     
     subroutine test_config_defaults()
@@ -90,7 +90,7 @@ contains
             error stop "Failed: output_format should default to text"
         end if
         
-        print *, "  OK Configuration defaults"
+        print *, "[OK] Configuration defaults"
     end subroutine test_config_defaults
     
     subroutine test_config_profiles()
@@ -113,7 +113,7 @@ contains
             error stop "Failed: performance profile should select rules"
         end if
         
-        print *, "  OK Configuration profiles"
+        print *, "[OK] Configuration profiles"
     end subroutine test_config_profiles
     
     subroutine test_schema_documentation()
@@ -139,7 +139,7 @@ contains
             error stop "Failed: schema should show TOML structure"
         end if
         
-        print *, "  OK Schema documentation"
+        print *, "[OK] Schema documentation"
     end subroutine test_schema_documentation
     
 end program test_config_schema

--- a/test/test_config_validation.f90
+++ b/test/test_config_validation.f90
@@ -17,7 +17,7 @@ program test_config_validation
     ! Test 4: Validate rule codes
     call test_rule_code_validation()
     
-    print *, "All configuration validation tests passed!"
+    print *, "[OK] All configuration validation tests passed!"
     
 contains
     
@@ -50,7 +50,7 @@ contains
             error stop "Failed: line length 1000 should be invalid"
         end if
         
-        print *, "  OK Line length validation"
+        print *, "[OK] Line length validation"
     end subroutine test_line_length_validation
     
     subroutine test_target_version_validation()
@@ -84,7 +84,7 @@ contains
             error stop "Failed: version 1995 should be invalid"
         end if
         
-        print *, "  OK Target version validation"
+        print *, "[OK] Target version validation"
     end subroutine test_target_version_validation
     
     subroutine test_output_format_validation()
@@ -118,7 +118,7 @@ contains
             error stop "Failed: format 'xml' should be invalid"
         end if
         
-        print *, "  OK Output format validation"
+        print *, "[OK] Output format validation"
     end subroutine test_output_format_validation
     
     subroutine test_rule_code_validation()
@@ -147,7 +147,7 @@ contains
             error stop "Failed: rule code X999 should be invalid"
         end if
         
-        print *, "  OK Rule code validation"
+        print *, "[OK] Rule code validation"
     end subroutine test_rule_code_validation
     
 end program test_config_validation

--- a/test/test_configuration_reload.f90
+++ b/test/test_configuration_reload.f90
@@ -7,7 +7,7 @@ program test_configuration_reload
     
     integer :: total_tests, passed_tests
     
-    print *, "=== Configuration Reload Test Suite (RED Phase) ==="
+    print *, "=== Configuration Reload Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -28,7 +28,7 @@ program test_configuration_reload
     if (passed_tests == total_tests) then
         print *, "[OK] All configuration reload tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -160,10 +160,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_config_test

--- a/test/test_dead_code_detection.f90
+++ b/test/test_dead_code_detection.f90
@@ -6,7 +6,7 @@ program test_dead_code_detection
     
     integer :: total_tests, passed_tests
     
-    print *, "=== Dead Code Detection Test Suite (RED Phase) ==="
+    print *, "=== Dead Code Detection Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -230,10 +230,10 @@ contains
         found_dead_code = test_proc()
         
         if (found_dead_code .eqv. should_find_dead_code) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_dead_code_test

--- a/test/test_dependency_analysis.f90
+++ b/test/test_dependency_analysis.f90
@@ -231,10 +231,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_dependency_test

--- a/test/test_diagnostic_formatting.f90
+++ b/test/test_diagnostic_formatting.f90
@@ -21,7 +21,7 @@ program test_diagnostic_formatting
     ! Test 5: Diagnostic with fix suggestions
     call test_diagnostic_with_fixes()
     
-    print *, "All diagnostic formatting tests passed!"
+    print *, "[OK] All diagnostic formatting tests passed!"
     
 contains
     
@@ -57,7 +57,7 @@ contains
             error stop "Formatted output should contain location information"
         end if
         
-        print *, "    OK Basic diagnostic formatting"
+        print *, "[OK] Basic diagnostic formatting"
         
     end subroutine test_basic_diagnostic_formatting
     
@@ -100,7 +100,7 @@ contains
             error stop "Formatted output should contain line numbers"
         end if
         
-        print *, "    OK Source code snippets in diagnostics"
+        print *, "[OK] Source code snippets in diagnostics"
         
     end subroutine test_source_code_snippets
     
@@ -140,7 +140,7 @@ contains
             error stop "SARIF output should be valid SARIF with ruleId field"
         end if
         
-        print *, "    OK Multiple output formats (text, JSON, SARIF)"
+        print *, "[OK] Multiple output formats (text, JSON, SARIF)"
         
     end subroutine test_multiple_output_formats
     
@@ -184,7 +184,7 @@ contains
             error stop "Info diagnostic should contain info indicator"
         end if
         
-        print *, "    OK Severity level formatting (error, warning, info)"
+        print *, "[OK] Severity level formatting (error, warning, info)"
         
     end subroutine test_severity_level_formatting
     
@@ -231,7 +231,7 @@ contains
             error stop "Formatted output should contain fix description"
         end if
         
-        print *, "    OK Diagnostic with fix suggestions"
+        print *, "[OK] Diagnostic with fix suggestions"
         
     end subroutine test_diagnostic_with_fixes
     

--- a/test/test_diagnostic_statistics.f90
+++ b/test/test_diagnostic_statistics.f90
@@ -15,7 +15,7 @@ program test_diagnostic_statistics
     ! Test 3: Collection statistics integration
     call test_collection_statistics()
     
-    print *, "All diagnostic statistics tests passed!"
+    print *, "[OK] All diagnostic statistics tests passed!"
     
 contains
     
@@ -63,7 +63,7 @@ contains
             error stop "Total formatting time should be 0.025"
         end if
         
-        print *, "    OK Basic statistics recording"
+        print *, "[OK] Basic statistics recording"
         
     end subroutine test_basic_statistics_recording
     
@@ -96,7 +96,7 @@ contains
             error stop "Summary should contain cache hit count"
         end if
         
-        print *, "    OK Statistics summary formatting"
+        print *, "[OK] Statistics summary formatting"
         
     end subroutine test_statistics_summary
     
@@ -145,7 +145,7 @@ contains
             error stop "Summary should not be empty"
         end if
         
-        print *, "    OK Collection statistics integration"
+        print *, "[OK] Collection statistics integration"
         
     end subroutine test_collection_statistics
     

--- a/test/test_enhanced_style_rules.f90
+++ b/test/test_enhanced_style_rules.f90
@@ -35,7 +35,7 @@ program test_enhanced_style_rules
     if (passed_tests == total_tests) then
         print *, "[OK] All enhanced style rules tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -382,17 +382,17 @@ contains
         call formatter%format_source(input, formatted_code, error_msg)
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Error: ", error_msg
             return
         end if
         
         ! For RED phase, just check that formatting completes
         ! In GREEN phase, we'll add specific validations for each rule
         if (len(formatted_code) > 0) then
-            print *, "  PASS: ", test_name, " (", expected_feature, ")"
+            print *, "[OK] ", test_name, " (", expected_feature, ")"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Empty output"
+            print *, "[FAIL] ", test_name, " - Empty output"
         end if
         
     end subroutine run_style_test

--- a/test/test_file_watching.f90
+++ b/test/test_file_watching.f90
@@ -5,7 +5,7 @@ program test_file_watching
     
     integer :: total_tests, passed_tests
     
-    print *, "=== File Watching Test Suite (RED Phase) ==="
+    print *, "=== File Watching Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -34,7 +34,7 @@ program test_file_watching
     if (passed_tests == total_tests) then
         print *, "[OK] All file watching tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -286,10 +286,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_watcher_test

--- a/test/test_fix_suggestions.f90
+++ b/test/test_fix_suggestions.f90
@@ -24,7 +24,7 @@ program test_fix_suggestions
     ! Test 6: Complex multi-edit fixes
     call test_complex_multi_edit_fixes()
     
-    print *, "All fix suggestion tests passed!"
+    print *, "[OK] All fix suggestion tests passed!"
     
 contains
     
@@ -80,7 +80,7 @@ contains
             error stop "Fix should be marked as safe"
         end if
         
-        print *, "    OK Basic fix generation"
+        print *, "[OK] Basic fix generation"
         
     end subroutine test_basic_fix_generation
     
@@ -124,7 +124,7 @@ contains
             error stop "Original code should be preserved"
         end if
         
-        print *, "    OK Fix application"
+        print *, "[OK] Fix application"
         
     end subroutine test_fix_application
     
@@ -193,7 +193,7 @@ contains
             error stop "Second fix should be unsafe"
         end if
         
-        print *, "    OK Multiple fixes per diagnostic"
+        print *, "[OK] Multiple fixes per diagnostic"
         
     end subroutine test_multiple_fixes_per_diagnostic
     
@@ -242,7 +242,7 @@ contains
             error stop "Should detect conflict between overlapping fixes"
         end if
         
-        print *, "    OK Fix conflict detection"
+        print *, "[OK] Fix conflict detection"
         
     end subroutine test_fix_conflict_detection
     
@@ -287,7 +287,7 @@ contains
             error stop "Unsafe fix should be marked as unsafe"
         end if
         
-        print *, "    OK Safe vs unsafe fixes"
+        print *, "[OK] Safe vs unsafe fixes"
         
     end subroutine test_safe_vs_unsafe_fixes
     
@@ -333,7 +333,7 @@ contains
         !     error stop "Should fix print statement"
         ! end if
         
-        print *, "    OK Complex multi-edit fixes"
+        print *, "[OK] Complex multi-edit fixes"
         
     end subroutine test_complex_multi_edit_fixes
     

--- a/test/test_fluff_ast_wrapper_api.f90
+++ b/test/test_fluff_ast_wrapper_api.f90
@@ -38,83 +38,83 @@ contains
         ctx = create_ast_context()
         call ctx%from_source(source, error_msg)
         if (len(error_msg) > 0) then
-            print *, "FAIL: from_source unexpected error: ", trim(error_msg)
+            print *, "[FAIL] from_source unexpected error: ", trim(error_msg)
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_text(stored, found)
         if (.not. found) then
-            print *, "FAIL: get_source_text found=false"
+            print *, "[FAIL] get_source_text found=false"
             test_source_text_api = .false.
             return
         end if
 
         if (index(stored, char(13)) > 0) then
-            print *, "FAIL: stored source contains CR character"
+            print *, "[FAIL] stored source contains CR character"
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_line(1, line, found)
         if (.not. found) then
-            print *, "FAIL: get_source_line(1) found=false"
+            print *, "[FAIL] get_source_line(1) found=false"
             test_source_text_api = .false.
             return
         end if
         if (line /= "program p") then
-            print *, "FAIL: get_source_line(1) mismatch: ", trim(line)
+            print *, "[FAIL] get_source_line(1) mismatch: ", trim(line)
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_line(2, line, found)
         if (.not. found) then
-            print *, "FAIL: get_source_line(2) found=false"
+            print *, "[FAIL] get_source_line(2) found=false"
             test_source_text_api = .false.
             return
         end if
         if (line /= "implicit none   ") then
-            print *, "FAIL: get_source_line(2) mismatch: ", trim(line)
+            print *, "[FAIL] get_source_line(2) mismatch: ", trim(line)
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_line(4, line, found)
         if (.not. found) then
-            print *, "FAIL: get_source_line(4) found=false"
+            print *, "[FAIL] get_source_line(4) found=false"
             test_source_text_api = .false.
             return
         end if
 
         if (line /= "x = 1") then
-            print *, "FAIL: get_source_line(4) mismatch: ", trim(line)
+            print *, "[FAIL] get_source_line(4) mismatch: ", trim(line)
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_line(6, line, found)
         if (.not. found) then
-            print *, "FAIL: get_source_line(6) found=false"
+            print *, "[FAIL] get_source_line(6) found=false"
             test_source_text_api = .false.
             return
         end if
 
         if (len(line) /= 0) then
-            print *, "FAIL: expected trailing empty line; got length=", len(line)
+            print *, "[FAIL] expected trailing empty line; got length=", len(line)
             test_source_text_api = .false.
             return
         end if
 
         call ctx%get_source_range(6, 1, 6, 1, text, found)
         if (.not. found) then
-            print *, "FAIL: get_source_range found=false"
+            print *, "[FAIL] get_source_range found=false"
             test_source_text_api = .false.
             return
         end if
 
         if (len(text) /= 0) then
-            print *, "FAIL: expected empty range; got length=", len(text)
+            print *, "[FAIL] expected empty range; got length=", len(text)
             test_source_text_api = .false.
             return
         end if
@@ -144,14 +144,14 @@ contains
         ctx_children = create_ast_context()
         call ctx_children%from_source(source_children, error_msg)
         if (len(error_msg) > 0) then
-            print *, "FAIL: from_source unexpected error: ", trim(error_msg)
+            print *, "[FAIL] from_source unexpected error: ", trim(error_msg)
             test_children_and_trivia_api = .false.
             return
         end if
 
         children = ctx_children%get_children(ctx_children%root_index)
         if (size(children) <= 0) then
-            print *, "FAIL: root has no children"
+            print *, "[FAIL] root has no children"
             test_children_and_trivia_api = .false.
             return
         end if
@@ -162,7 +162,7 @@ contains
         ctx_trivia = create_ast_context()
         call ctx_trivia%from_source(source_trivia, error_msg)
         if (len(error_msg) > 0) then
-            print *, "FAIL: from_source unexpected error: ", trim(error_msg)
+            print *, "[FAIL] from_source unexpected error: ", trim(error_msg)
             test_children_and_trivia_api = .false.
             return
         end if
@@ -176,26 +176,26 @@ contains
         end do
 
         if (assignment_index == 0) then
-            print *, "FAIL: did not find assignment node"
+            print *, "[FAIL] did not find assignment node"
             test_children_and_trivia_api = .false.
             return
         end if
 
         call ctx_trivia%get_trivia_for_node(assignment_index, leading, trailing, found)
         if (.not. found) then
-            print *, "FAIL: get_trivia_for_node found=false"
+            print *, "[FAIL] get_trivia_for_node found=false"
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (size(leading) /= 3) then
-            print *, "FAIL: expected 3 leading trivia tokens; got=", size(leading)
+            print *, "[FAIL] expected 3 leading trivia tokens; got=", size(leading)
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (leading(1)%kind /= CST_COMMENT) then
-            print *, "FAIL: expected first trivia CST_COMMENT; got kind=", &
+            print *, "[FAIL] expected first trivia CST_COMMENT; got kind=", &
                 leading(1)%kind
             test_children_and_trivia_api = .false.
             return
@@ -207,34 +207,34 @@ contains
         end if
 
         if (trim(leading(1)%text) /= "! header") then
-            print *, "FAIL: unexpected comment text: ", trim(leading(1)%text)
+            print *, "[FAIL] unexpected comment text: ", trim(leading(1)%text)
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (leading(2)%kind /= CST_NEWLINE) then
-            print *, "FAIL: expected second trivia CST_NEWLINE; got kind=", &
+            print *, "[FAIL] expected second trivia CST_NEWLINE; got kind=", &
                 leading(2)%kind
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (leading(3)%kind /= CST_WHITESPACE) then
-            print *, "FAIL: expected third trivia CST_WHITESPACE; got kind=", &
+            print *, "[FAIL] expected third trivia CST_WHITESPACE; got kind=", &
                 leading(3)%kind
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (leading(3)%text /= "   ") then
-            print *, "FAIL: unexpected indentation trivia: ", &
+            print *, "[FAIL] unexpected indentation trivia: ", &
                 trim(leading(3)%text)
             test_children_and_trivia_api = .false.
             return
         end if
 
         if (size(trailing) <= 0) then
-            print *, "FAIL: expected trailing trivia tokens"
+            print *, "[FAIL] expected trailing trivia tokens"
             test_children_and_trivia_api = .false.
             return
         end if
@@ -259,35 +259,35 @@ contains
         ctx = create_ast_context()
         call ctx%from_source(source, error_msg)
         if (len(error_msg) > 0) then
-            print *, "FAIL: from_source unexpected error: ", trim(error_msg)
+            print *, "[FAIL] from_source unexpected error: ", trim(error_msg)
             test_symbol_query_api = .false.
             return
         end if
 
         defined = ctx%is_symbol_defined("x")
         if (.not. defined) then
-            print *, "FAIL: expected x to be defined"
+            print *, "[FAIL] expected x to be defined"
             test_symbol_query_api = .false.
             return
         end if
 
         defined = ctx%is_symbol_defined("does_not_exist")
         if (defined) then
-            print *, "FAIL: expected does_not_exist to be undefined"
+            print *, "[FAIL] expected does_not_exist to be undefined"
             test_symbol_query_api = .false.
             return
         end if
 
         x_info = ctx%lookup_symbol("x")
         if (.not. x_info%is_defined) then
-            print *, "FAIL: lookup_symbol(x) returned is_defined=false"
+            print *, "[FAIL] lookup_symbol(x) returned is_defined=false"
             test_symbol_query_api = .false.
             return
         end if
 
         symbols = ctx%get_all_symbols()
         if (size(symbols) <= 0) then
-            print *, "FAIL: expected non-empty symbol list"
+            print *, "[FAIL] expected non-empty symbol list"
             test_symbol_query_api = .false.
             return
         end if

--- a/test/test_format_quality_analysis.f90
+++ b/test/test_format_quality_analysis.f90
@@ -545,7 +545,7 @@ contains
         ! But this causes memory corruption in fortfront semantic analyzer
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Format error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Format error: ", error_msg
             return
         end if
         
@@ -567,7 +567,7 @@ contains
         quality_score = quality_score + aspect_score
         
         if (aspect_score >= 7) then
-            print *, "  PASS: ", test_name, " - Score: ", aspect_score, "/10"
+            print *, "[OK] ", test_name, " - Score: ", aspect_score, "/10"
             passed_tests = passed_tests + 1
         else
             print *, "  NEEDS IMPROVEMENT: ", test_name, " - Score: ", aspect_score, "/10"
@@ -771,10 +771,10 @@ contains
         
         print *, ""
         print *, "Recommended next steps:"
-        print *, "- Focus on spacing and indentation improvements"
-        print *, "- Enhance readability with better blank line usage"
-        print *, "- Implement advanced expression formatting"
-        print *, "- Add aesthetic quality metrics to formatter"
+        print *, "[WARN] Focus on spacing and indentation improvements"
+        print *, "[WARN] Enhance readability with better blank line usage"
+        print *, "[WARN] Implement advanced expression formatting"
+        print *, "[WARN] Add aesthetic quality metrics to formatter"
         
     end subroutine generate_quality_recommendations
     

--- a/test/test_format_validation.f90
+++ b/test/test_format_validation.f90
@@ -28,9 +28,9 @@ program test_format_validation
     print *, "Success rate: ", real(passed_tests)/real(total_tests)*100.0, "%"
 
     if (passed_tests == total_tests) then
-        print *, "All format validation tests passed."
+        print *, "[OK] All format validation tests passed."
     else
-        print *, "Some validation tests failed."
+        print *, "[FAIL] Some validation tests failed."
     end if
 
 contains
@@ -386,7 +386,7 @@ contains
         open (newunit=unit, file=temp_path, status='replace', action='write', &
               iostat=iostat)
         if (iostat /= 0) then
-            print *, "  FAIL: file open for write"
+            print *, "[FAIL] file open for write"
             return
         end if
 
@@ -399,12 +399,12 @@ contains
 
         call formatter%format_file(temp_path, formatted_code, error_msg)
         if (error_msg /= "") then
-            print *, "  FAIL: file format error: ", error_msg
+            print *, "[FAIL] file format error: ", error_msg
             return
         end if
 
         if (index(formatted_code, "program test") == 0) then
-            print *, "  FAIL: formatted output missing program"
+            print *, "[FAIL] formatted output missing program"
             return
         end if
 
@@ -414,7 +414,7 @@ contains
             close (unit, status='delete')
         end if
 
-        print *, "  PASS: file formatting"
+        print *, "[OK] file formatting"
         passed_tests = passed_tests + 1
     end subroutine test_file_formatting
 
@@ -430,17 +430,17 @@ contains
         call formatter%format_source(input, formatted_code, error_msg)
 
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Format error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Format error: ", error_msg
             return
         end if
 
         call formatter%validate_format(input, formatted_code, is_valid)
 
         if (is_valid .eqv. should_validate) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Expected validation: ", &
+            print *, "[FAIL] ", test_name, " - Expected validation: ", &
                 should_validate, ", got: ", is_valid
         end if
 
@@ -455,23 +455,23 @@ contains
         ! First formatting
         call formatter%format_source(input, first_format, error_msg)
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - First format error: ", error_msg
+            print *, "[FAIL] ", test_name, " - First format error: ", error_msg
             return
         end if
 
         ! Second formatting (roundtrip)
         call formatter%format_source(first_format, second_format, error_msg)
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Second format error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Second format error: ", error_msg
             return
         end if
 
         ! Check idempotency
         if (first_format == second_format) then
-            print *, "  PASS: ", test_name, " - Roundtrip stable"
+            print *, "[OK] ", test_name, " - Roundtrip stable"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Roundtrip not stable"
+            print *, "[FAIL] ", test_name, " - Roundtrip not stable"
         end if
 
     end subroutine run_roundtrip_test
@@ -486,14 +486,14 @@ contains
         call formatter%format_source(input, formatted_code, error_msg)
 
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Format error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Format error: ", error_msg
             return
         end if
 
         call formatter%validate_format(input, formatted_code, is_valid)
 
         ! For interface testing, we just check that the validation runs
-        print *, "  PASS: ", test_name, " - Validation result: ", is_valid
+        print *, "[OK] ", test_name, " - Validation result: ", is_valid
         passed_tests = passed_tests + 1
 
     end subroutine run_interface_test
@@ -508,11 +508,11 @@ contains
         call formatter%compare_semantics(input1, input2, semantically_equal)
 
         if (semantically_equal .eqv. should_match) then
-            print *, "  PASS: ", test_name, " - Semantic comparison: ", &
+            print *, "[OK] ", test_name, " - Semantic comparison: ", &
                 semantically_equal
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Expected: ", should_match, &
+            print *, "[FAIL] ", test_name, " - Expected: ", should_match, &
                 ", got: ", semantically_equal
         end if
 
@@ -531,10 +531,10 @@ contains
         call formatter%analyze_format_diff(original, formatted, diff_type)
 
         if (index(diff_type, expected_diff_type) > 0) then
-            print *, "  PASS: ", test_name, " - Diff type: ", diff_type
+            print *, "[OK] ", test_name, " - Diff type: ", diff_type
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Expected: ", expected_diff_type, &
+            print *, "[FAIL] ", test_name, " - Expected: ", expected_diff_type, &
                 ", got: ", diff_type
         end if
 

--- a/test/test_formatter_advanced.f90
+++ b/test/test_formatter_advanced.f90
@@ -14,7 +14,7 @@ program test_formatter_advanced
     
     print *, "=== Testing Advanced Formatter Features ==="
     
-    ! RED Phase: All these tests should fail initially
+    ! These tests exercise advanced formatter behavior
     call test_complex_expression_formatting()
     call test_array_literal_formatting()
     ! call test_procedure_formatting()      ! DISABLED: fortfront function parameter bug
@@ -23,7 +23,7 @@ program test_formatter_advanced
     ! call test_configurable_styles()      ! DISABLED: likely more complex issues
     ! call test_format_range()             ! DISABLED: likely more complex issues
     
-    print *, "All advanced formatter tests passed!"
+    print *, "[OK] All advanced formatter tests passed!"
     
 contains
     
@@ -108,7 +108,7 @@ contains
         
         call format_and_check(source_code, expected, "Binary operator alignment")
         
-        print *, "    OK Complex expression formatting"
+        print *, "[OK] Complex expression formatting"
     end subroutine test_complex_expression_formatting
     
     subroutine test_array_literal_formatting()
@@ -164,7 +164,7 @@ contains
         
         call format_and_check(source_code, expected, "Nested array constructors")
         
-        print *, "    OK Array literal formatting"
+        print *, "[OK] Array literal formatting"
     end subroutine test_array_literal_formatting
     
     subroutine test_procedure_formatting()
@@ -234,7 +234,7 @@ contains
         
         call format_and_check(source_code, expected, "Interface block formatting")
         
-        print *, "    OK Procedure formatting"
+        print *, "[OK] Procedure formatting"
     end subroutine test_procedure_formatting
     
     subroutine test_comment_preservation()
@@ -281,7 +281,7 @@ contains
         
         call format_and_check(source_code, expected, "Block comment preservation")
         
-        print *, "    OK Comment preservation"
+        print *, "[OK] Comment preservation"
     end subroutine test_comment_preservation
     
     subroutine test_import_organization()
@@ -328,7 +328,7 @@ contains
         
         call format_and_check(source_code, expected, "Import grouping")
         
-        print *, "    OK Import organization"
+        print *, "[OK] Import organization"
     end subroutine test_import_organization
     
     subroutine test_configurable_styles()
@@ -368,7 +368,7 @@ contains
         
         call format_with_options_and_check(source_code, expected, options, "Tab indentation")
         
-        print *, "    OK Configurable styles"
+        print *, "[OK] Configurable styles"
     end subroutine test_configurable_styles
     
     subroutine test_format_range()
@@ -404,7 +404,7 @@ contains
         
         call format_range_and_check(source_code, expected, start_line, end_line, "Format range")
         
-        print *, "    OK Format range support"
+        print *, "[OK] Format range support"
     end subroutine test_format_range
     
     ! Helper subroutines
@@ -417,13 +417,13 @@ contains
         local_ast_ctx = create_ast_context()
         call local_ast_ctx%from_source(source, error_msg)
         if (error_msg /= "") then
-            print *, "FAIL: " // test_name // " - Parse error: " // error_msg
+            print *, "[FAIL] " // test_name // " - Parse error: " // error_msg
             print *, "ERROR: "; return ! "Parse failed"
         end if
         call formatter%format_ast(local_ast_ctx, actual)
         
         if (actual /= expected) then
-            print *, "FAIL: " // test_name
+            print *, "[FAIL] " // test_name
             print *, "Expected:"
             print *, expected
             print *, "Actual:"
@@ -442,13 +442,13 @@ contains
         local_ast_ctx = create_ast_context()
         call local_ast_ctx%from_source(source, error_msg)
         if (error_msg /= "") then
-            print *, "FAIL: " // test_name // " - Parse error: " // error_msg
+            print *, "[FAIL] " // test_name // " - Parse error: " // error_msg
             print *, "ERROR: "; return ! "Parse failed"
         end if
         call formatter%format_ast(local_ast_ctx, actual)
         
         if (actual /= expected) then
-            print *, "FAIL: " // test_name
+            print *, "[FAIL] " // test_name
             print *, "Expected:"
             print *, expected
             print *, "Actual:"
@@ -467,13 +467,13 @@ contains
         local_ast_ctx = create_ast_context()
         call local_ast_ctx%from_source(source, error_msg)
         if (error_msg /= "") then
-            print *, "FAIL: " // test_name // " - Parse error: " // error_msg
+            print *, "[FAIL] " // test_name // " - Parse error: " // error_msg
             print *, "ERROR: "; return ! "Parse failed"
         end if
         call formatter%format_range(local_ast_ctx, start_line, end_line, actual)
         
         if (actual /= expected) then
-            print *, "FAIL: " // test_name
+            print *, "[FAIL] " // test_name
             print *, "Expected:"
             print *, expected
             print *, "Actual:"

--- a/test/test_formatter_comprehensive.f90
+++ b/test/test_formatter_comprehensive.f90
@@ -301,16 +301,16 @@ contains
         call formatter%format_source(input, actual, error_msg)
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Error: ", error_msg
             return
         end if
         
         ! Flexible matching - check key structural elements
         if (contains_key_elements(actual, expected)) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
             print *, "    Expected structure elements from: ", expected
             print *, "    Actual: ", actual
             ! Still count as passed if basic structure is correct
@@ -330,16 +330,16 @@ contains
         call formatter%format_source(input, actual, error_msg)
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Error: ", error_msg
             return
         end if
         
         ! Just check that basic structure is preserved
         if (index(actual, "program test") > 0 .and. index(actual, "end program") > 0) then
-            print *, "  PASS: ", test_name, " (flexible)"
+            print *, "[OK] ", test_name, " (flexible)"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Structure not preserved"
+            print *, "[FAIL] ", test_name, " - Structure not preserved"
             print *, "    Actual: ", actual
         end if
         

--- a/test/test_formatter_framework.f90
+++ b/test/test_formatter_framework.f90
@@ -22,7 +22,7 @@ program test_formatter_framework
     ! Test 5: Format options configuration
     call test_format_options()
     
-    print *, "All formatter framework tests passed!"
+    print *, "[OK] All formatter framework tests passed!"
     
 contains
     
@@ -83,7 +83,7 @@ contains
             error stop "Should apply indentation to code blocks"
         end if
         
-        print *, "    OK Basic indentation formatting"
+        print *, "[OK] Basic indentation formatting"
         
     end subroutine test_basic_indentation
     
@@ -125,7 +125,7 @@ contains
             error stop "Should preserve program end"
         end if
         
-        print *, "    OK Operator spacing"
+        print *, "[OK] Operator spacing"
         
     end subroutine test_operator_spacing
     
@@ -173,7 +173,7 @@ contains
             error stop "Should preserve program structure"
         end if
         
-        print *, "    OK Semantic preservation"
+        print *, "[OK] Semantic preservation"
         
     end subroutine test_semantic_preservation
     
@@ -211,7 +211,7 @@ contains
             error stop "Should preserve assignment"
         end if
         
-        print *, "    OK Comment preservation"
+        print *, "[OK] Comment preservation"
         
     end subroutine test_comment_preservation
     
@@ -252,7 +252,7 @@ contains
             error stop "Should preserve indent size setting"
         end if
         
-        print *, "    OK Format options configuration"
+        print *, "[OK] Format options configuration"
         
     end subroutine test_format_options
     

--- a/test/test_formatter_quality.f90
+++ b/test/test_formatter_quality.f90
@@ -17,7 +17,7 @@ program test_formatter_quality
     call test_format_stability()
     call test_whitespace_normalization()
     
-    print *, "All formatter quality tests passed!"
+    print *, "[OK] All formatter quality tests passed!"
     
 contains
     
@@ -51,7 +51,7 @@ contains
         if (indent_violations > 0) then
             print *, "  Warning: Found indentation inconsistencies"
         else
-            print *, "  OK Perfect indentation consistency"
+            print *, "[OK] Perfect indentation consistency"
         end if
         
     end subroutine test_indentation_consistency
@@ -80,7 +80,7 @@ contains
                  real(count_lines(formatted_code) - long_lines) / real(count_lines(formatted_code)) * 100.0, "%"
         
         if (long_lines == 0) then
-            print *, "  OK All lines within length limit"
+            print *, "[OK] All lines within length limit"
         else
             print *, "  Warning: Some lines exceed length limit"
         end if
@@ -118,7 +118,7 @@ contains
         print *, "  Semantic preservation: ", semantically_identical
         
         if (semantically_identical) then
-            print *, "  OK Perfect semantic preservation"
+            print *, "[OK] Perfect semantic preservation"
         else
             print *, "  Warning: Semantic differences detected"
             print *, "  Original normalized: ", original_normalized
@@ -159,7 +159,7 @@ contains
         print *, "  Second format length: ", len(second_format)
         
         if (is_stable) then
-            print *, "  OK Format is stable (idempotent)"
+            print *, "[OK] Format is stable (idempotent)"
         else
             print *, "  Warning: Format is unstable"
             print *, "  First: ", first_format
@@ -194,7 +194,7 @@ contains
                  real(count_lines(formatted_code)) * 100.0, "%"
         
         if (trailing_spaces == 0 .and. inconsistent_spacing == 0) then
-            print *, "  OK Perfect whitespace normalization"
+            print *, "[OK] Perfect whitespace normalization"
         else
             print *, "  Warning: Whitespace issues detected"
         end if

--- a/test/test_fortran_specific_style.f90
+++ b/test/test_fortran_specific_style.f90
@@ -31,7 +31,7 @@ program test_fortran_specific_style
     if (passed_tests == total_tests) then
         print *, "[OK] All Fortran-specific style tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -392,17 +392,17 @@ contains
         call formatter%format_source(input, formatted_code, error_msg)
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Error: ", error_msg
             return
         end if
         
         ! For RED phase, just check that formatting completes
         ! In GREEN phase, we'll add specific validations for each principle
         if (len(formatted_code) > 0) then
-            print *, "  PASS: ", test_name, " (", expected_feature, ")"
+            print *, "[OK] ", test_name, " (", expected_feature, ")"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Empty output"
+            print *, "[FAIL] ", test_name, " - Empty output"
         end if
         
     end subroutine run_style_test

--- a/test/test_incremental_analysis.f90
+++ b/test/test_incremental_analysis.f90
@@ -6,7 +6,7 @@ program test_incremental_analysis
     
     integer :: total_tests, passed_tests
     
-    print *, "=== Incremental Analysis Test Suite (RED Phase) ==="
+    print *, "=== Incremental Analysis Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -28,7 +28,7 @@ program test_incremental_analysis
     if (passed_tests == total_tests) then
         print *, "[OK] All incremental analysis tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -174,10 +174,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_analysis_test

--- a/test/test_integration_quality.f90
+++ b/test/test_integration_quality.f90
@@ -28,7 +28,7 @@ program test_integration_quality
     if (passed_tests == total_tests) then
         print *, "[OK] All integration quality tests passed!"
     else
-        print *, "[FAIL] Some tests failed (TDD stubs in progress)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -200,10 +200,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_quality_test

--- a/test/test_intelligent_caching.f90
+++ b/test/test_intelligent_caching.f90
@@ -30,7 +30,7 @@ program test_intelligent_caching
     if (passed_tests == total_tests) then
         print *, "[OK] All intelligent caching tests passed!"
     else
-        print *, "[FAIL] Some tests failed (TDD stubs in progress)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -264,10 +264,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_cache_test

--- a/test/test_lsp_code_actions.f90
+++ b/test/test_lsp_code_actions.f90
@@ -8,7 +8,7 @@ program test_lsp_code_actions
     integer :: total_tests, passed_tests
     real(dp) :: success_rate
 
-    print *, "=== LSP Code Actions Test Suite (RED Phase) ==="
+    print *, "=== LSP Code Actions Test Suite ==="
 
     total_tests = 0
     passed_tests = 0
@@ -35,7 +35,7 @@ program test_lsp_code_actions
     if (passed_tests == total_tests) then
         print *, "[OK] All LSP code action tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
 
 contains
@@ -245,22 +245,22 @@ contains
         if (success .and. action_count == expected_count) then
             if (expected_count > 0) then
                 if (.not. allocated(actions)) then
-                    print *, "  FAIL: ", test_name, " - Actions not allocated"
+                    print *, "[FAIL] ", test_name, " - Actions not allocated"
                 else if (size(actions) < 1) then
-                    print *, "  FAIL: ", test_name, " - No actions returned"
+                    print *, "[FAIL] ", test_name, " - No actions returned"
                 else if (index(actions(1), expected_action) > 0) then
-                    print *, "  PASS: ", test_name, " - Generated ", &
+                    print *, "[OK] ", test_name, " - Generated ", &
                         action_count, " actions"
                     passed_tests = passed_tests + 1
                 else
-                    print *, "  FAIL: ", test_name, " - Wrong action generated"
+                    print *, "[FAIL] ", test_name, " - Wrong action generated"
                 end if
             else
-                print *, "  PASS: ", test_name, " - No actions as expected"
+                print *, "[OK] ", test_name, " - No actions as expected"
                 passed_tests = passed_tests + 1
             end if
         else
-            print *, "  FAIL: ", test_name, " - Expected ", expected_count, ", got ", &
+            print *, "[FAIL] ", test_name, " - Expected ", expected_count, ", got ", &
                 action_count
         end if
 
@@ -284,10 +284,10 @@ contains
                                 formatted_action, success)
 
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Formatting result unexpected"
+            print *, "[FAIL] ", test_name, " - Formatting result unexpected"
         end if
 
     end subroutine run_format_test
@@ -308,17 +308,17 @@ contains
         call apply_code_action(original, result, edit_count, success)
 
         if (success .neqv. should_succeed) then
-            print *, "  FAIL: ", test_name, " - Application result unexpected"
+            print *, "[FAIL] ", test_name, " - Application result unexpected"
         else if (.not. should_succeed) then
-            print *, "  PASS: ", test_name, " - Application failed as expected"
+            print *, "[OK] ", test_name, " - Application failed as expected"
             passed_tests = passed_tests + 1
         else if (.not. allocated(result)) then
-            print *, "  FAIL: ", test_name, " - Result not allocated"
+            print *, "[FAIL] ", test_name, " - Result not allocated"
         else if (result == expected) then
-            print *, "  PASS: ", test_name, " - Applied ", edit_count, " edits"
+            print *, "[OK] ", test_name, " - Applied ", edit_count, " edits"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Result doesn't match expected"
+            print *, "[FAIL] ", test_name, " - Result doesn't match expected"
             print *, "        Expected:"
             print *, "        '", expected, "'"
             print *, "        Got:"
@@ -347,10 +347,10 @@ contains
                                    action_count, success)
 
         if (success .and. action_count == expected_count) then
-            print *, "  PASS: ", test_name, " - Generated ", action_count, " actions"
+            print *, "[OK] ", test_name, " - Generated ", action_count, " actions"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Expected ", expected_count, ", got ", &
+            print *, "[FAIL] ", test_name, " - Expected ", expected_count, ", got ", &
                 action_count
         end if
 
@@ -374,10 +374,10 @@ contains
         call apply_fix_all(file_uris, diagnostic_code, fixes_applied, success)
 
         if (success .eqv. should_succeed .and. fixes_applied == expected_fixes) then
-            print *, "  PASS: ", test_name, " - Applied ", fixes_applied, " fixes"
+            print *, "[OK] ", test_name, " - Applied ", fixes_applied, " fixes"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Fix-all result unexpected"
+            print *, "[FAIL] ", test_name, " - Fix-all result unexpected"
         end if
 
     end subroutine run_fixall_test
@@ -402,10 +402,10 @@ contains
                                           action_count, success)
 
         if (success .eqv. should_succeed .and. action_count == expected_count) then
-            print *, "  PASS: ", test_name, " - Found ", action_count, " actions"
+            print *, "[OK] ", test_name, " - Found ", action_count, " actions"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Context handling failed"
+            print *, "[FAIL] ", test_name, " - Context handling failed"
         end if
 
     end subroutine run_context_test

--- a/test/test_lsp_diagnostics.f90
+++ b/test/test_lsp_diagnostics.f90
@@ -46,30 +46,30 @@ contains
         call lint_to_notification("file:///test.f90", sample_code_ok(), expected, ok)
         total_tests = total_tests + 1
         if (.not. ok) then
-            print *, "  FAIL: Expected notification generation"
+            print *, "[FAIL] Expected notification generation"
             return
         end if
 
         call server%handle_text_document_did_open("file:///test.f90", "fortran", 1, &
                                                   sample_code_ok(), ok)
         if (.not. ok) then
-            print *, "  FAIL: Server didOpen"
+            print *, "[FAIL] Server didOpen"
             return
         end if
 
         call server%pop_notification(actual, found)
         if (.not. found) then
-            print *, "  FAIL: Server did not produce diagnostics notification"
+            print *, "[FAIL] Server did not produce diagnostics notification"
             return
         end if
 
         if (actual /= expected) then
-            print *, "  FAIL: Server diagnostics notification mismatch"
+            print *, "[FAIL] Server diagnostics notification mismatch"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Server diagnostics matches formatter"
+        print *, "[OK] Server diagnostics matches formatter"
     end subroutine test_server_publish_matches_formatter
 
     subroutine test_clear_diagnostics_notification()
@@ -82,37 +82,37 @@ contains
         total_tests = total_tests + 1
         call lsp_clear_diagnostics_notification("file:///test.f90", notification, ok)
         if (.not. ok) then
-            print *, "  FAIL: Clear notification generation"
+            print *, "[FAIL] Clear notification generation"
             return
         end if
 
         call json_parse(notification, ok, err)
         if (.not. ok) then
-            print *, "  FAIL: Clear notification JSON invalid"
+            print *, "[FAIL] Clear notification JSON invalid"
             return
         end if
 
         call json_get_member_json(notification, "params", params_json, found, ok)
         if (.not. ok .or. .not. found) then
-            print *, "  FAIL: Clear notification missing params"
+            print *, "[FAIL] Clear notification missing params"
             return
         end if
 
         call json_get_member_json(params_json, "diagnostics", &
                                   diagnostics_json, found, ok)
         if (.not. ok .or. .not. found) then
-            print *, "  FAIL: Clear notification missing diagnostics"
+            print *, "[FAIL] Clear notification missing diagnostics"
             return
         end if
 
         call json_array_length(diagnostics_json, n, ok)
         if (.not. ok .or. n /= 0) then
-            print *, "  FAIL: Clear notification diagnostics not empty"
+            print *, "[FAIL] Clear notification diagnostics not empty"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Clear diagnostics notification"
+        print *, "[OK] Clear diagnostics notification"
     end subroutine test_clear_diagnostics_notification
 
     subroutine test_realtime_updates()
@@ -126,26 +126,26 @@ contains
         call lint_to_notification("file:///rt.f90", sample_code_ok(), expected1, ok)
         total_tests = total_tests + 1
         if (.not. ok) then
-            print *, "  FAIL: Expected realtime notification 1"
+            print *, "[FAIL] Expected realtime notification 1"
             return
         end if
 
         call lint_to_notification("file:///rt.f90", sample_code_changed(), &
                                   expected2, ok)
         if (.not. ok) then
-            print *, "  FAIL: Expected realtime notification 2"
+            print *, "[FAIL] Expected realtime notification 2"
             return
         end if
 
         call server%handle_text_document_did_open("file:///rt.f90", "fortran", 1, &
                                                   sample_code_ok(), ok)
         if (.not. ok) then
-            print *, "  FAIL: Server didOpen realtime"
+            print *, "[FAIL] Server didOpen realtime"
             return
         end if
         call server%pop_notification(actual1, found)
         if (.not. found .or. actual1 /= expected1) then
-            print *, "  FAIL: Realtime open notification mismatch"
+            print *, "[FAIL] Realtime open notification mismatch"
             return
         end if
 
@@ -153,17 +153,17 @@ contains
                                                     sample_code_changed(), &
                                                     ok)
         if (.not. ok) then
-            print *, "  FAIL: Server didChange realtime"
+            print *, "[FAIL] Server didChange realtime"
             return
         end if
         call server%pop_notification(actual2, found)
         if (.not. found .or. actual2 /= expected2) then
-            print *, "  FAIL: Realtime change notification mismatch"
+            print *, "[FAIL] Realtime change notification mismatch"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Realtime diagnostics updates"
+        print *, "[OK] Realtime diagnostics updates"
     end subroutine test_realtime_updates
 
     subroutine test_single_diagnostic_format_json()
@@ -174,30 +174,30 @@ contains
         call lint_to_diagnostics(sample_code_ok(), diagnostics, ok)
         total_tests = total_tests + 1
         if (.not. ok) then
-            print *, "  FAIL: Lint failed for formatting test"
+            print *, "[FAIL] Lint failed for formatting test"
             return
         end if
 
         if (size(diagnostics) == 0) then
             passed_tests = passed_tests + 1
-            print *, "  PASS: Diagnostic formatting skipped with no diagnostics"
+            print *, "[OK] Diagnostic formatting skipped with no diagnostics"
             return
         end if
 
         call lsp_format_diagnostic(diagnostics(1), formatted, ok)
         if (.not. ok) then
-            print *, "  FAIL: Diagnostic formatting failed"
+            print *, "[FAIL] Diagnostic formatting failed"
             return
         end if
 
         call assert_valid_json(formatted, ok)
         if (.not. ok) then
-            print *, "  FAIL: Diagnostic formatting JSON invalid"
+            print *, "[FAIL] Diagnostic formatting JSON invalid"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Diagnostic formatting JSON"
+        print *, "[OK] Diagnostic formatting JSON"
     end subroutine test_single_diagnostic_format_json
 
     subroutine lint_to_notification(uri, content, notification, success)

--- a/test/test_lsp_document_sync.f90
+++ b/test/test_lsp_document_sync.f90
@@ -46,22 +46,22 @@ contains
                                                   "end program", success)
 
         if (.not. success) then
-            print *, "  FAIL: Document open"
+            print *, "[FAIL] Document open"
             return
         end if
 
         if (server%workspace%document_count /= 1) then
-            print *, "  FAIL: Document open - unexpected document_count"
+            print *, "[FAIL] Document open - unexpected document_count"
             return
         end if
 
         if (server%workspace%documents(1)%uri /= "file:///test.f90") then
-            print *, "  FAIL: Document open - unexpected uri"
+            print *, "[FAIL] Document open - unexpected uri"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Document open"
+        print *, "[OK] Document open"
 
         call server%pop_notification(notification, found)
         if (found) then
@@ -69,9 +69,9 @@ contains
             total_tests = total_tests + 1
             if (success) then
                 passed_tests = passed_tests + 1
-                print *, "  PASS: Diagnostics notification after open"
+                print *, "[OK] Diagnostics notification after open"
             else
-                print *, "  FAIL: Diagnostics notification after open"
+                print *, "[FAIL] Diagnostics notification after open"
                 return
             end if
         end if
@@ -85,47 +85,47 @@ contains
                                                     "end program", success)
 
         if (.not. success) then
-            print *, "  FAIL: Document change"
+            print *, "[FAIL] Document change"
             return
         end if
 
         if (server%workspace%documents(1)%version /= 2) then
-            print *, "  FAIL: Document change - version not updated"
+            print *, "[FAIL] Document change - version not updated"
             return
         end if
 
         if (index(server%workspace%documents(1)%content, "x = 2") == 0) then
-            print *, "  FAIL: Document change - content not updated"
+            print *, "[FAIL] Document change - content not updated"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Document change"
+        print *, "[OK] Document change"
 
         total_tests = total_tests + 1
         call server%handle_text_document_did_save("file:///test.f90", success)
         if (success) then
             passed_tests = passed_tests + 1
-            print *, "  PASS: Document save"
+            print *, "[OK] Document save"
         else
-            print *, "  FAIL: Document save"
+            print *, "[FAIL] Document save"
             return
         end if
 
         total_tests = total_tests + 1
         call server%handle_text_document_did_close("file:///test.f90", success)
         if (.not. success) then
-            print *, "  FAIL: Document close"
+            print *, "[FAIL] Document close"
             return
         end if
 
         if (server%workspace%document_count /= 0) then
-            print *, "  FAIL: Document close - document_count not decremented"
+            print *, "[FAIL] Document close - document_count not decremented"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Document close"
+        print *, "[OK] Document close"
     end subroutine test_document_lifecycle
 
     subroutine test_workspace_multiple_documents()
@@ -141,7 +141,7 @@ contains
                                                   "end program", success)
 
         if (.not. success) then
-            print *, "  FAIL: Open first document"
+            print *, "[FAIL] Open first document"
             return
         end if
 
@@ -151,28 +151,28 @@ contains
                                                   "end program", success)
 
         if (.not. success) then
-            print *, "  FAIL: Open second document"
+            print *, "[FAIL] Open second document"
             return
         end if
 
         if (server%workspace%document_count /= 2) then
-            print *, "  FAIL: Multiple documents - unexpected document_count"
+            print *, "[FAIL] Multiple documents - unexpected document_count"
             return
         end if
 
         call server%handle_text_document_did_close("file:///a.f90", success)
         if (.not. success) then
-            print *, "  FAIL: Close first document"
+            print *, "[FAIL] Close first document"
             return
         end if
 
         if (server%workspace%document_count /= 1) then
-            print *, "  FAIL: Multiple documents - close did not remove"
+            print *, "[FAIL] Multiple documents - close did not remove"
             return
         end if
 
         passed_tests = passed_tests + 1
-        print *, "  PASS: Multiple documents open/close"
+        print *, "[OK] Multiple documents open/close"
     end subroutine test_workspace_multiple_documents
 
     subroutine test_uri_parsing()
@@ -183,9 +183,9 @@ contains
         call uri_to_path("file:///home/user/project/main.f90", path, success)
         if (success .and. path == "/home/user/project/main.f90") then
             passed_tests = passed_tests + 1
-            print *, "  PASS: URI parsing"
+            print *, "[OK] URI parsing"
         else
-            print *, "  FAIL: URI parsing"
+            print *, "[FAIL] URI parsing"
             return
         end if
 
@@ -193,9 +193,9 @@ contains
         call uri_to_path("file:///C:/Users/user/project/main.f90", path, success)
         if (success .and. path == "C:/Users/user/project/main.f90") then
             passed_tests = passed_tests + 1
-            print *, "  PASS: Windows URI parsing"
+            print *, "[OK] Windows URI parsing"
         else
-            print *, "  FAIL: Windows URI parsing"
+            print *, "[FAIL] Windows URI parsing"
             return
         end if
 
@@ -203,9 +203,9 @@ contains
         call uri_to_path("file:///../relative/path.f90", path, success)
         if (success .and. path == "../relative/path.f90") then
             passed_tests = passed_tests + 1
-            print *, "  PASS: Relative path URI parsing"
+            print *, "[OK] Relative path URI parsing"
         else
-            print *, "  FAIL: Relative path URI parsing"
+            print *, "[FAIL] Relative path URI parsing"
             return
         end if
 
@@ -213,9 +213,9 @@ contains
         call uri_to_path("file:///path%20with%20spaces/file.f90", path, success)
         if (success .and. path == "/path with spaces/file.f90") then
             passed_tests = passed_tests + 1
-            print *, "  PASS: Percent decoding"
+            print *, "[OK] Percent decoding"
         else
-            print *, "  FAIL: Percent decoding"
+            print *, "[FAIL] Percent decoding"
             return
         end if
     end subroutine test_uri_parsing

--- a/test/test_lsp_goto_definition.f90
+++ b/test/test_lsp_goto_definition.f90
@@ -6,7 +6,7 @@ program test_lsp_goto_definition
     integer :: total_tests, passed_tests
     real(dp) :: success_rate
 
-    print *, "=== LSP Goto Definition Test Suite (RED Phase) ==="
+    print *, "=== LSP Goto Definition Test Suite ==="
 
     total_tests = 0
     passed_tests = 0
@@ -33,7 +33,7 @@ program test_lsp_goto_definition
     if (passed_tests == total_tests) then
         print *, "[OK] All LSP goto definition tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
 
 contains
@@ -286,19 +286,19 @@ contains
                              result_char, success)
 
         if (success .neqv. should_succeed) then
-            print *, "  FAIL: ", test_name, " - Definition lookup failed"
+            print *, "[FAIL] ", test_name, " - Definition lookup failed"
         else if (.not. should_succeed) then
-            print *, "  PASS: ", test_name, " - No definition as expected"
+            print *, "[OK] ", test_name, " - No definition as expected"
             passed_tests = passed_tests + 1
         else if (.not. allocated(result_uri)) then
-            print *, "  FAIL: ", test_name, " - Result URI not allocated"
+            print *, "[FAIL] ", test_name, " - Result URI not allocated"
         else if (result_uri == expected_uri .and. &
                  result_line == expected_line .and. &
                  result_char == expected_char) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Wrong location"
+            print *, "[FAIL] ", test_name, " - Wrong location"
             print *, "        Expected: ", expected_uri, ":", expected_line, ":", &
                 expected_char
             print *, "        Got:      ", result_uri, ":", result_line, ":", &

--- a/test/test_lsp_hover.f90
+++ b/test/test_lsp_hover.f90
@@ -6,7 +6,7 @@ program test_lsp_hover
     integer :: total_tests, passed_tests
     real(dp) :: success_rate
 
-    print *, "=== LSP Hover Provider Test Suite (RED Phase) ==="
+    print *, "=== LSP Hover Provider Test Suite ==="
 
     total_tests = 0
     passed_tests = 0
@@ -33,7 +33,7 @@ program test_lsp_hover
     if (passed_tests == total_tests) then
         print *, "[OK] All LSP hover tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
 
 contains
@@ -247,18 +247,18 @@ contains
         call get_hover_info(code, line, character, hover_content, success)
 
         if (success .neqv. should_succeed) then
-            print *, "  FAIL: ", test_name, " - Hover result unexpected"
+            print *, "[FAIL] ", test_name, " - Hover result unexpected"
             print *, "        Success: ", success, " Expected: ", should_succeed
         else if (.not. should_succeed) then
-            print *, "  PASS: ", test_name, " - No hover as expected"
+            print *, "[OK] ", test_name, " - No hover as expected"
             passed_tests = passed_tests + 1
         else if (.not. allocated(hover_content)) then
-            print *, "  FAIL: ", test_name, " - Hover content not allocated"
+            print *, "[FAIL] ", test_name, " - Hover content not allocated"
         else if (index(hover_content, expected_hover) > 0) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Wrong hover content"
+            print *, "[FAIL] ", test_name, " - Wrong hover content"
             print *, "        Expected to contain: '", expected_hover, "'"
             print *, "        Got: '", hover_content, "'"
         end if
@@ -281,17 +281,17 @@ contains
         call format_hover_message(signature, documentation, formatted, success)
 
         if (success .neqv. should_succeed) then
-            print *, "  FAIL: ", test_name, " - Formatting result unexpected"
+            print *, "[FAIL] ", test_name, " - Formatting result unexpected"
         else if (.not. should_succeed) then
-            print *, "  PASS: ", test_name, " - Formatting failed as expected"
+            print *, "[OK] ", test_name, " - Formatting failed as expected"
             passed_tests = passed_tests + 1
         else if (.not. allocated(formatted)) then
-            print *, "  FAIL: ", test_name, " - Formatted content not allocated"
+            print *, "[FAIL] ", test_name, " - Formatted content not allocated"
         else if (formatted == expected) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Format doesn't match"
+            print *, "[FAIL] ", test_name, " - Format doesn't match"
         end if
 
     end subroutine run_format_test

--- a/test/test_lsp_message_handling.f90
+++ b/test/test_lsp_message_handling.f90
@@ -228,7 +228,7 @@ contains
         call parse_lsp_message(json_message, message_type, message_id, method, success)
 
         if (.not. success) then
-            print *, "  FAIL: ", test_name, " - Failed to parse message"
+            print *, "[FAIL] ", test_name, " - Failed to parse message"
             print *, "        Message was: '", json_message, "'"
             return
         end if
@@ -237,10 +237,10 @@ contains
         if (message_type == expected_type .and. &
             (expected_id == -1 .or. message_id == expected_id) .and. &
             (len(expected_method) == 0 .or. method == expected_method)) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Expected type='", expected_type, &
+            print *, "[FAIL] ", test_name, " - Expected type='", expected_type, &
                 "', got='", message_type, "'"
             print *, "        Expected id=", expected_id, ", got=", message_id
             print *, "        Expected method='", expected_method, "', got='", &
@@ -259,10 +259,10 @@ contains
         call process_initialize_request(json_message, success)
 
         if (success) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Initialize processing failed"
+            print *, "[FAIL] ", test_name, " - Initialize processing failed"
         end if
 
     end subroutine run_initialize_test
@@ -277,10 +277,10 @@ contains
         call process_document_sync(json_message, success)
 
         if (success) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Document sync processing failed"
+            print *, "[FAIL] ", test_name, " - Document sync processing failed"
         end if
 
     end subroutine run_document_test
@@ -295,10 +295,10 @@ contains
         call process_diagnostic_message(json_message, success)
 
         if (success) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Diagnostic processing failed"
+            print *, "[FAIL] ", test_name, " - Diagnostic processing failed"
         end if
 
     end subroutine run_diagnostic_test
@@ -316,10 +316,10 @@ contains
         call process_capabilities(full_json, success)
 
         if (success) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Capability processing failed"
+            print *, "[FAIL] ", test_name, " - Capability processing failed"
         end if
 
     end subroutine run_capability_test
@@ -335,10 +335,10 @@ contains
         call check_message_errors(json_message, error_type, has_error)
 
         if (has_error .and. error_type == expected_error_type) then
-            print *, "  PASS: ", test_name, " - Correctly detected error: ", error_type
+            print *, "[OK] ", test_name, " - Correctly detected error: ", error_type
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Error handling failed"
+            print *, "[FAIL] ", test_name, " - Error handling failed"
         end if
 
     end subroutine run_error_test

--- a/test/test_metrics.f90
+++ b/test/test_metrics.f90
@@ -18,7 +18,7 @@ program test_metrics
     ! Test 4: Metrics reporting
     call test_metrics_report()
     
-    print *, "All metrics tests passed!"
+    print *, "[OK] All metrics tests passed!"
     
 contains
     
@@ -38,7 +38,7 @@ contains
         ! Test stop functionality
         call timer%stop()
         
-        print *, "  OK Timer functionality"
+        print *, "[OK] Timer functionality"
         
     end subroutine test_timer
     
@@ -76,7 +76,7 @@ contains
             error stop "Failed: stats should be reset"
         end if
         
-        print *, "  OK Rule statistics"
+        print *, "[OK] Rule statistics"
         
     end subroutine test_rule_stats
     
@@ -129,7 +129,7 @@ contains
             error stop "Failed: disabled collector should not record"
         end if
         
-        print *, "  OK Metrics collector"
+        print *, "[OK] Metrics collector"
         
     end subroutine test_metrics_collector
     
@@ -159,7 +159,7 @@ contains
             error stop "Failed: report should contain rule code"
         end if
         
-        print *, "  OK Metrics reporting"
+        print *, "[OK] Metrics reporting"
         
     end subroutine test_metrics_report
     

--- a/test/test_metrics_integration.f90
+++ b/test/test_metrics_integration.f90
@@ -19,7 +19,7 @@ program test_metrics_integration
     ! Test 3: Metrics reset
     call test_metrics_reset()
     
-    print *, "All metrics integration tests passed!"
+    print *, "[OK] All metrics integration tests passed!"
     
 contains
     
@@ -42,7 +42,7 @@ contains
             error stop "Failed: should show 0 rules executed initially"
         end if
         
-        print *, "  OK Metrics collection during execution"
+        print *, "[OK] Metrics collection during execution"
         
     end subroutine test_execution_metrics
     
@@ -61,7 +61,7 @@ contains
             error stop "Failed: report should contain header"
         end if
         
-        print *, "  OK Metrics report generation"
+        print *, "[OK] Metrics report generation"
         
     end subroutine test_metrics_report
     
@@ -87,7 +87,7 @@ contains
             error stop "Failed: metrics should be reset"
         end if
         
-        print *, "  OK Metrics reset"
+        print *, "[OK] Metrics reset"
         
     end subroutine test_metrics_reset
     

--- a/test/test_module_compilation.f90
+++ b/test/test_module_compilation.f90
@@ -28,6 +28,6 @@ program test_module_compilation
         error stop "Context creation failed"
     end if
     
-    print *, "All modules compiled successfully!"
+    print *, "[OK] All modules compiled successfully!"
     
 end program test_module_compilation

--- a/test/test_output_formats.f90
+++ b/test/test_output_formats.f90
@@ -6,7 +6,7 @@ program test_output_formats
     
     integer :: total_tests, passed_tests
     
-    print *, "=== Multiple Output Formats Test Suite (RED Phase) ==="
+    print *, "=== Multiple Output Formats Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -28,7 +28,7 @@ program test_output_formats
     if (passed_tests == total_tests) then
         print *, "[OK] All output format tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -226,10 +226,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_format_test

--- a/test/test_parallel_rule_execution.f90
+++ b/test/test_parallel_rule_execution.f90
@@ -18,7 +18,7 @@ program test_parallel_rule_execution
     ! Test 3: Result consistency
     call test_result_consistency()
 
-    print *, "All parallel rule execution tests passed!"
+    print *, "[OK] All parallel rule execution tests passed!"
 
 contains
 
@@ -57,7 +57,7 @@ contains
             error stop "Failed: invalid timing results"
         end if
 
-        print *, "  OK Parallel execution performance"
+        print *, "[OK] Parallel execution performance"
 
     end subroutine test_parallel_performance
 
@@ -91,7 +91,7 @@ contains
             end if
         end do
 
-        print *, "  OK Thread safety"
+        print *, "[OK] Thread safety"
 
     end subroutine test_thread_safety
 
@@ -124,7 +124,7 @@ contains
             error stop "Failed: serial and parallel results differ"
         end if
 
-        print *, "  OK Result consistency"
+        print *, "[OK] Result consistency"
 
     end subroutine test_result_consistency
 

--- a/test/test_quality_improvements.f90
+++ b/test/test_quality_improvements.f90
@@ -170,7 +170,7 @@ contains
         if (size(quality_before%recommendations) > 0) then
             print *, "    Recommendations:"
             do i = 1, min(3, size(quality_before%recommendations))
-                print *, "      - ", trim(quality_before%recommendations(i))
+                print *, "      ", i, ". ", trim(quality_before%recommendations(i))
             end do
         end if
         
@@ -189,7 +189,7 @@ contains
         call formatter%format_with_quality(input_code, formatted_code, error_msg, quality_after)
         
         if (error_msg /= "") then
-            print *, "  SKIP: ", test_name, " - Format error: ", error_msg
+            print *, "[WARN] ", test_name, " - Format error: ", error_msg
             return
         end if
         
@@ -198,7 +198,7 @@ contains
         print *, "    After:  ", quality_after%overall_score, "/10"
         
         if (quality_after%overall_score >= quality_before%overall_score) then
-            print *, "    OK Quality maintained or improved"
+            print *, "[OK] Quality maintained or improved"
             passed_tests = passed_tests + 1
         else
             print *, "    [WARN] Quality decreased"

--- a/test/test_rule_documentation_examples.f90
+++ b/test/test_rule_documentation_examples.f90
@@ -68,7 +68,7 @@ contains
                               generate_f008_bad_example(), &
                               generate_f008_good_example())
 
-        print *, "    OK Style rule examples completed (F001-F008)"
+        print *, "[OK] Style rule examples completed (F001-F008)"
         
     end subroutine generate_style_rule_examples
     
@@ -117,7 +117,7 @@ contains
                               generate_p007_bad_example(), &
                               generate_p007_good_example())
         
-        print *, "    OK Performance rule examples completed (P001-P007)"
+        print *, "[OK] Performance rule examples completed (P001-P007)"
         
     end subroutine generate_performance_rule_examples
     
@@ -130,7 +130,7 @@ contains
                               generate_c001_bad_example(), &
                               generate_c001_good_example())
         
-        print *, "    OK Correctness rule examples completed (C001)"
+        print *, "[OK] Correctness rule examples completed (C001)"
         
     end subroutine generate_correctness_rule_examples
     

--- a/test/test_rule_f001_implicit_none.f90
+++ b/test/test_rule_f001_implicit_none.f90
@@ -23,7 +23,7 @@ program test_rule_f001_implicit_none
     ! Test 5: Interface blocks should not trigger
     call test_interface_block()
 
-    print *, "All F001 tests passed!"
+    print *, "[OK] All F001 tests passed!"
 
 contains
 
@@ -68,7 +68,7 @@ contains
             error stop "Failed: F001 should be triggered for missing implicit none"
         end if
 
-        print *, "  OK Missing implicit none in program"
+        print *, "[OK] Missing implicit none in program"
 
     end subroutine test_missing_implicit_none
 
@@ -115,7 +115,7 @@ contains
                 "is present"
         end if
 
-        print *, "  OK Has implicit none"
+        print *, "[OK] Has implicit none"
 
     end subroutine test_has_implicit_none
 
@@ -162,7 +162,7 @@ contains
                 "implicit none"
         end if
 
-        print *, "  OK Module missing implicit none"
+        print *, "[OK] Module missing implicit none"
 
     end subroutine test_module_missing_implicit_none
 
@@ -206,7 +206,7 @@ contains
                 "implicit none"
         end if
 
-        print *, "  OK Subroutine missing implicit none"
+        print *, "[OK] Subroutine missing implicit none"
 
     end subroutine test_subroutine_missing_implicit_none
 
@@ -254,7 +254,7 @@ contains
             error stop "Failed: F001 should not be triggered for interface blocks"
         end if
 
-        print *, "  OK Interface block handling"
+        print *, "[OK] Interface block handling"
 
     end subroutine test_interface_block
 

--- a/test/test_rule_f002_indentation.f90
+++ b/test/test_rule_f002_indentation.f90
@@ -20,7 +20,7 @@ program test_rule_f002_indentation
     ! Test 4: Mixed indentation levels (should trigger)
     call test_mixed_levels()
 
-    print *, "All F002 tests passed!"
+    print *, "[OK] All F002 tests passed!"
 
 contains
 
@@ -64,7 +64,7 @@ contains
             error stop "Failed: F002 should be triggered for inconsistent indentation"
         end if
 
-        print *, "  OK Inconsistent indentation"
+        print *, "[OK] Inconsistent indentation"
 
     end subroutine test_inconsistent_indentation
 
@@ -107,7 +107,7 @@ contains
             error stop "Failed: F002 should not be triggered for consistent indentation"
         end if
 
-        print *, "  OK Consistent 4-space indentation"
+        print *, "[OK] Consistent 4-space indentation"
 
     end subroutine test_consistent_4_spaces
 
@@ -149,7 +149,7 @@ contains
                 "2-space indentation"
         end if
 
-        print *, "  OK Consistent 2-space indentation"
+        print *, "[OK] Consistent 2-space indentation"
     end subroutine test_consistent_2_spaces
 
     subroutine test_mixed_levels()
@@ -189,7 +189,7 @@ contains
             error stop "Failed: F002 should be triggered for mixed indentation levels"
         end if
 
-        print *, "  OK Mixed indentation levels"
+        print *, "[OK] Mixed indentation levels"
     end subroutine test_mixed_levels
 
 end program test_rule_f002_indentation

--- a/test/test_rule_f003_line_length.f90
+++ b/test/test_rule_f003_line_length.f90
@@ -27,7 +27,7 @@ program test_rule_f003_line_length
     ! Test 6: Tabs count toward visual columns
     call test_tabs_column_calculation()
 
-    print *, "All F003 tests passed!"
+    print *, "[OK] All F003 tests passed!"
 
 contains
 
@@ -92,7 +92,7 @@ contains
             error stop "Failed: F003 location should point to the overflow span"
         end if
 
-        print *, "  OK Line too long"
+        print *, "[OK] Line too long"
 
     end subroutine test_line_too_long
 
@@ -139,7 +139,7 @@ contains
             error stop "Failed: F003 should not be triggered for lines within limit"
         end if
 
-        print *, "  OK Line within limit"
+        print *, "[OK] Line within limit"
 
     end subroutine test_line_within_limit
 
@@ -198,7 +198,7 @@ contains
             error stop "Failed: F003 location should point to the overflow span"
         end if
 
-        print *, "  OK Long physical line detected"
+        print *, "[OK] Long physical line detected"
 
     end subroutine test_continuation_lines
 
@@ -250,7 +250,7 @@ contains
                 "lines"
         end if
 
-        print *, "  OK Comment lines correctly ignored"
+        print *, "[OK] Comment lines correctly ignored"
 
     end subroutine test_comment_lines
 
@@ -300,7 +300,7 @@ contains
             error stop "Failed: F003 should respect configured line length"
         end if
 
-        print *, "  OK Custom line length respected"
+        print *, "[OK] Custom line length respected"
     end subroutine test_custom_line_length
 
     subroutine test_tabs_column_calculation()
@@ -357,7 +357,7 @@ contains
             error stop "Failed: F003 location end column should account for tabs"
         end if
 
-        print *, "  OK Tabs counted as visual columns"
+        print *, "[OK] Tabs counted as visual columns"
     end subroutine test_tabs_column_calculation
 
 end program test_rule_f003_line_length

--- a/test/test_rule_f004_trailing_whitespace.f90
+++ b/test/test_rule_f004_trailing_whitespace.f90
@@ -20,7 +20,7 @@ program test_rule_f004_trailing_whitespace
     ! Test 4: Trailing tabs
     call test_trailing_tabs()
 
-    print *, "All F004 tests passed!"
+    print *, "[OK] All F004 tests passed!"
 
 contains
 
@@ -61,7 +61,7 @@ contains
         open (unit=99, file=path, status="old")
         close (99, status="delete")
 
-        print *, "  OK Trailing whitespace"
+        print *, "[OK] Trailing whitespace"
 
     end subroutine test_trailing_whitespace
 
@@ -96,7 +96,7 @@ contains
 
         call assert_equal_int(f004_count, 0, "Expected 0 F004 violations")
 
-        print *, "  OK No trailing whitespace"
+        print *, "[OK] No trailing whitespace"
 
     end subroutine test_no_trailing_whitespace
 
@@ -137,7 +137,7 @@ contains
         call assert_f004_location(diagnostics, 3, 17, 18)
         call assert_f004_location(diagnostics, 4, 14, 16)
 
-        print *, "  OK Multiple trailing spaces"
+        print *, "[OK] Multiple trailing spaces"
 
     end subroutine test_multiple_trailing_spaces
 
@@ -174,7 +174,7 @@ contains
         open (unit=99, file=path, status="old")
         close (99, status="delete")
 
-        print *, "  OK Trailing tabs"
+        print *, "[OK] Trailing tabs"
 
     end subroutine test_trailing_tabs
 

--- a/test/test_rule_f005_mixed_tabs_spaces.f90
+++ b/test/test_rule_f005_mixed_tabs_spaces.f90
@@ -18,7 +18,7 @@ program test_rule_f005_mixed_tabs_spaces
     ! Test 4: Multiple mixed indentations
     call test_multiple_mixed()
 
-    print *, "All F005 tests passed!"
+    print *, "[OK] All F005 tests passed!"
 
 contains
 
@@ -56,7 +56,7 @@ contains
         open (unit=99, file=path, status="old")
         close (99, status="delete")
 
-        print *, "  OK Mixed tabs and spaces"
+        print *, "[OK] Mixed tabs and spaces"
 
     end subroutine test_mixed_tabs_spaces
 
@@ -93,7 +93,7 @@ contains
 
         call assert_equal_int(f005_count, 0, "Expected 0 F005 violations")
 
-        print *, "  OK Only spaces"
+        print *, "[OK] Only spaces"
 
     end subroutine test_only_spaces
 
@@ -131,7 +131,7 @@ contains
 
         call assert_equal_int(f005_count, 0, "Expected 0 F005 violations")
 
-        print *, "  OK Only tabs"
+        print *, "[OK] Only tabs"
 
     end subroutine test_only_tabs
 
@@ -175,7 +175,7 @@ contains
         call assert_f005_location(diagnostics, 4, 1, 3)
         call assert_f005_location(diagnostics, 5, 1, 3)
 
-        print *, "  OK Multiple mixed indentations"
+        print *, "[OK] Multiple mixed indentations"
 
     end subroutine test_multiple_mixed
 

--- a/test/test_rule_f006_unused_variable.f90
+++ b/test/test_rule_f006_unused_variable.f90
@@ -20,7 +20,7 @@ program test_rule_f006_unused_variable
     ! Test 4: Unused parameter vs used variable
     call test_unused_parameter()
 
-    print *, "All F006 tests passed!"
+    print *, "[OK] All F006 tests passed!"
 
 contains
 
@@ -66,7 +66,7 @@ contains
             error stop "Failed: F006 should be triggered for unused variable"
         end if
 
-        print *, "  - Unused variable"
+        print *, "[OK] Unused variable"
 
     end subroutine test_unused_variable
 
@@ -112,7 +112,7 @@ contains
             error stop "Failed: F006 should not be triggered when variables are used"
         end if
 
-        print *, "  - Used variable"
+        print *, "[OK] Used variable"
 
     end subroutine test_used_variable
 
@@ -152,7 +152,7 @@ contains
                 "Failed: expected 2+ F006 diagnostics for multiple unused variables"
         end if
 
-        print *, "  - Multiple unused variables"
+        print *, "[OK] Multiple unused variables"
     end subroutine test_multiple_unused
 
     subroutine test_unused_parameter()
@@ -196,7 +196,7 @@ contains
                 "Failed: F006 should not be triggered for unused parameter-only cases"
         end if
 
-        print *, "  - Unused parameter"
+        print *, "[OK] Unused parameter"
     end subroutine test_unused_parameter
 
 end program test_rule_f006_unused_variable

--- a/test/test_rule_f007_undefined_variable.f90
+++ b/test/test_rule_f007_undefined_variable.f90
@@ -20,7 +20,7 @@ program test_rule_f007_undefined_variable
     ! Test 4: Variable defined in different scope
     call test_scope_visibility()
 
-    print *, "All F007 tests passed!"
+    print *, "[OK] All F007 tests passed!"
 
 contains
 
@@ -65,7 +65,7 @@ contains
             error stop "Failed: F007 should be triggered for undefined variable"
         end if
 
-        print *, "  - Undefined variable usage"
+        print *, "[OK] Undefined variable usage"
 
     end subroutine test_undefined_variable
 
@@ -112,7 +112,7 @@ contains
             error stop "Failed: F007 should not be triggered when variables are defined"
         end if
 
-        print *, "  - Defined variable"
+        print *, "[OK] Defined variable"
 
     end subroutine test_defined_variable
 
@@ -152,7 +152,7 @@ contains
                 "Failed: expected 2+ F007 diagnostics for multiple undefined variables"
         end if
 
-        print *, "  - Multiple undefined variables"
+        print *, "[OK] Multiple undefined variables"
     end subroutine test_multiple_undefined
 
     subroutine test_scope_visibility()
@@ -200,7 +200,7 @@ contains
             error stop "Failed: expected F007 for out-of-scope variable"
         end if
 
-        print *, "  - Variable scope visibility"
+        print *, "[OK] Variable scope visibility"
     end subroutine test_scope_visibility
 
 end program test_rule_f007_undefined_variable

--- a/test/test_rule_f008_missing_intent.f90
+++ b/test/test_rule_f008_missing_intent.f90
@@ -20,7 +20,7 @@ program test_rule_f008_missing_intent
     ! Test 4: Function parameters without intent
     call test_function_parameters()
 
-    print *, "All F008 tests passed!"
+    print *, "[OK] All F008 tests passed!"
 
 contains
 
@@ -69,7 +69,7 @@ contains
             error stop "Failed: F008 should be triggered for missing intent"
         end if
 
-        print *, "  OK Missing intent declarations"
+        print *, "[OK] Missing intent declarations"
 
     end subroutine test_missing_intent
 
@@ -120,7 +120,7 @@ contains
                 "properly declared"
         end if
 
-        print *, "  OK Proper intent declarations"
+        print *, "[OK] Proper intent declarations"
 
     end subroutine test_proper_intent
 
@@ -165,7 +165,7 @@ contains
             error stop "Failed: F008 should be triggered for mixed intent declarations"
         end if
 
-        print *, "  OK Mixed intent declarations"
+        print *, "[OK] Mixed intent declarations"
     end subroutine test_mixed_intent
 
     subroutine test_function_parameters()
@@ -207,7 +207,7 @@ contains
                 "without intent"
         end if
 
-        print *, "  OK Function parameters"
+        print *, "[OK] Function parameters"
     end subroutine test_function_parameters
 
 end program test_rule_f008_missing_intent

--- a/test/test_rule_f009_inconsistent_intent.f90
+++ b/test/test_rule_f009_inconsistent_intent.f90
@@ -14,7 +14,7 @@ program test_rule_f009_inconsistent_intent
     call test_intent_out_unassigned()
     call test_intent_out_assigned()
 
-    print *, "All F009 tests passed!"
+    print *, "[OK] All F009 tests passed!"
 
 contains
 
@@ -41,7 +41,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "F009", .true., &
                                         "intent(in) assignment should be flagged")
-        print *, "  + Intent(in) modified"
+        print *, "[OK] Intent(in) modified"
     end subroutine test_intent_in_modified
 
     subroutine test_intent_in_not_modified()
@@ -68,7 +68,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "F009", .false., &
                                         "no intent violations expected")
-        print *, "  + Intent(in) not modified"
+        print *, "[OK] Intent(in) not modified"
     end subroutine test_intent_in_not_modified
 
     subroutine test_intent_out_unassigned()
@@ -94,7 +94,7 @@ contains
         call assert_has_diagnostic_code(diagnostics, "F009", .true., &
                                         "intent(out) without assignment should be "// &
                                         "flagged")
-        print *, "  + Intent(out) unassigned"
+        print *, "[OK] Intent(out) unassigned"
     end subroutine test_intent_out_unassigned
 
     subroutine test_intent_out_assigned()
@@ -120,7 +120,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "F009", .false., &
                                         "no intent violations expected")
-        print *, "  + Intent(out) assigned"
+        print *, "[OK] Intent(out) assigned"
     end subroutine test_intent_out_assigned
 
 end program test_rule_f009_inconsistent_intent

--- a/test/test_rule_f010_obsolete_features.f90
+++ b/test/test_rule_f010_obsolete_features.f90
@@ -20,7 +20,7 @@ program test_rule_f010_obsolete_features
     ! Test 4: Arithmetic IF statement (should trigger)
     call test_arithmetic_if()
 
-    print *, "All F010 tests passed!"
+    print *, "[OK] All F010 tests passed!"
 
 contains
 

--- a/test/test_rule_f011_missing_end_labels.f90
+++ b/test/test_rule_f011_missing_end_labels.f90
@@ -20,7 +20,7 @@ program test_rule_f011_missing_end_labels
     ! Test 4: Function end labels
     call test_function_end_labels()
 
-    print *, "All F011 tests passed!"
+    print *, "[OK] All F011 tests passed!"
 
 contains
 

--- a/test/test_rule_f012_naming_conventions.f90
+++ b/test/test_rule_f012_naming_conventions.f90
@@ -20,7 +20,7 @@ program test_rule_f012_naming_conventions
     ! Test 4: Mixed naming styles (should trigger)
     call test_mixed_naming_styles()
 
-    print *, "All F012 tests passed!"
+    print *, "[OK] All F012 tests passed!"
 
 contains
 

--- a/test/test_rule_f013_multiple_statements.f90
+++ b/test/test_rule_f013_multiple_statements.f90
@@ -20,7 +20,7 @@ program test_rule_f013_multiple_statements
     ! Test 4: Complex multi-statement lines
     call test_complex_multi_statements()
 
-    print *, "All F013 tests passed!"
+    print *, "[OK] All F013 tests passed!"
 
 contains
 

--- a/test/test_rule_f014_unnecessary_parentheses.f90
+++ b/test/test_rule_f014_unnecessary_parentheses.f90
@@ -20,7 +20,7 @@ program test_rule_f014_unnecessary_parentheses
     ! Test 4: Function call parentheses
     call test_function_call_parentheses()
 
-    print *, "All F014 tests passed!"
+    print *, "[OK] All F014 tests passed!"
 
 contains
 
@@ -73,7 +73,7 @@ contains
             error stop "Failed: F014 should be triggered for unnecessary parentheses"
         end if
 
-        print *, "  OK Unnecessary parentheses"
+        print *, "[OK] Unnecessary parentheses"
 
     end subroutine test_unnecessary_parentheses
 
@@ -127,7 +127,7 @@ contains
             error stop "Failed: F014 should not be triggered for necessary parentheses"
         end if
 
-        print *, "  OK Necessary parentheses"
+        print *, "[OK] Necessary parentheses"
 
     end subroutine test_necessary_parentheses
 
@@ -172,7 +172,7 @@ contains
                 "clarity parentheses"
         end if
 
-        print *, "  OK Expression clarity parentheses"
+        print *, "[OK] Expression clarity parentheses"
     end subroutine test_expression_clarity
 
     subroutine test_function_call_parentheses()
@@ -215,7 +215,7 @@ contains
                 "Failed: F014 should not be triggered for function call parentheses"
         end if
 
-        print *, "  OK Function call parentheses"
+        print *, "[OK] Function call parentheses"
     end subroutine test_function_call_parentheses
 
 end program test_rule_f014_unnecessary_parentheses

--- a/test/test_rule_f015_redundant_continue.f90
+++ b/test/test_rule_f015_redundant_continue.f90
@@ -29,7 +29,7 @@ program test_rule_f015_redundant_continue
     ! Test 7: Named fmt=/format= label and continue
     call test_named_format_label_continue()
 
-    print *, "All F015 tests passed!"
+    print *, "[OK] All F015 tests passed!"
 
 contains
 
@@ -87,7 +87,7 @@ contains
             error stop "Failed: F015 should be triggered for redundant continue"
         end if
 
-        print *, "  OK: Redundant continue statements"
+        print *, "[OK] Redundant continue statements"
 
     end subroutine test_redundant_continue
 
@@ -116,7 +116,7 @@ contains
                 "statements"
         end if
 
-        print *, "  OK: No continue statements"
+        print *, "[OK] No continue statements"
 
     end subroutine test_no_continue
 
@@ -143,7 +143,7 @@ contains
             error stop "Failed: F015 should not be triggered for labeled branch target"
         end if
 
-        print *, "  OK: Necessary continue statements"
+        print *, "[OK] Necessary continue statements"
     end subroutine test_necessary_continue
 
     subroutine test_loop_labels_continue()
@@ -169,7 +169,7 @@ contains
             error stop "Failed: F015 should not be triggered for DO end label"
         end if
 
-        print *, "  OK: Loop labels and continue"
+        print *, "[OK] Loop labels and continue"
     end subroutine test_loop_labels_continue
 
     subroutine test_io_label_targets_continue()
@@ -194,7 +194,7 @@ contains
             error stop "Failed: F015 should not flag I/O label target CONTINUE"
         end if
 
-        print *, "  OK: I/O label targets and continue"
+        print *, "[OK] I/O label targets and continue"
     end subroutine test_io_label_targets_continue
 
     subroutine test_positional_format_label_continue()
@@ -218,7 +218,7 @@ contains
             error stop "Failed: F015 should not flag positional FORMAT label CONTINUE"
         end if
 
-        print *, "  OK: Positional FORMAT label and continue"
+        print *, "[OK] Positional FORMAT label and continue"
     end subroutine test_positional_format_label_continue
 
     subroutine test_named_format_label_continue()
@@ -244,7 +244,7 @@ contains
             error stop "Failed: F015 should not flag fmt=/format= label CONTINUE"
         end if
 
-        print *, "  OK: Named fmt=/format= label and continue"
+        print *, "[OK] Named fmt=/format= label and continue"
     end subroutine test_named_format_label_continue
 
 end program test_rule_f015_redundant_continue

--- a/test/test_rule_false_positive_analysis.f90
+++ b/test/test_rule_false_positive_analysis.f90
@@ -43,7 +43,7 @@ contains
         ! F005: mixed tabs/spaces - test consistent formatting
         call test_f005_valid_cases()
 
-        print *, "    OK Style rule false positive analysis completed"
+        print *, "[OK] Style rule false positive analysis completed"
 
     end subroutine analyze_style_rule_false_positives
 
@@ -62,7 +62,7 @@ contains
         ! P004: pure/elemental - test cases where not applicable
         call test_p004_valid_cases()
 
-        print *, "    OK Performance rule false positive analysis completed"
+        print *, "[OK] Performance rule false positive analysis completed"
 
     end subroutine analyze_performance_rule_false_positives
 
@@ -72,7 +72,7 @@ contains
         ! C001: undefined variable - test valid variable usage
         call test_c001_valid_cases()
 
-        print *, "    OK Correctness rule false positive analysis completed"
+        print *, "[OK] Correctness rule false positive analysis completed"
 
     end subroutine analyze_correctness_rule_false_positives
 
@@ -88,7 +88,7 @@ contains
         ! Test modern Fortran features
         call test_modern_features()
 
-        print *, "    OK Edge case false positive analysis completed"
+        print *, "[OK] Edge case false positive analysis completed"
 
     end subroutine analyze_edge_case_false_positives
 

--- a/test/test_rule_interface.f90
+++ b/test/test_rule_interface.f90
@@ -22,7 +22,7 @@ program test_rule_interface
     ! Test 4: Rule metadata
     call test_rule_metadata()
 
-    print *, "All rule interface tests passed!"
+    print *, "[OK] All rule interface tests passed!"
 
 contains
 
@@ -60,7 +60,7 @@ contains
             error stop "Failed: expected at least one violation"
         end if
 
-        print *, "  OK Rule execution lifecycle"
+        print *, "[OK] Rule execution lifecycle"
     end subroutine test_rule_lifecycle
 
     subroutine test_rule_registration()
@@ -93,7 +93,7 @@ contains
             error stop "Failed: should have 1 registered rule"
         end if
 
-        print *, "  OK Rule registration"
+        print *, "[OK] Rule registration"
     end subroutine test_rule_registration
 
     subroutine test_rule_context()
@@ -124,7 +124,7 @@ contains
             error stop "Failed: line count incorrect"
         end if
 
-        print *, "  OK Rule context access"
+        print *, "[OK] Rule context access"
     end subroutine test_rule_context
 
     subroutine test_rule_metadata()
@@ -157,7 +157,7 @@ contains
             error stop "Failed: metadata should contain fixable flag"
         end if
 
-        print *, "  OK Rule metadata"
+        print *, "[OK] Rule metadata"
     end subroutine test_rule_metadata
 
 end program test_rule_interface

--- a/test/test_rule_p001_column_major_access.f90
+++ b/test/test_rule_p001_column_major_access.f90
@@ -16,7 +16,7 @@ program test_rule_p001_column_major_access
     call test_rhs_array_read_triggers()
     call test_non_array_call_ok()
 
-    print *, "All P001 tests passed!"
+    print *, "[OK] All P001 tests passed!"
 
 contains
 
@@ -48,7 +48,7 @@ contains
                                         "outer loop varying leftmost index")
         call assert_diagnostic_location(diagnostics, "P001", 8, 24, &
                                         "P001 should point at array reference")
-        print *, "  + 2D incorrect ordering triggers"
+        print *, "[OK] 2D incorrect ordering triggers"
     end subroutine test_2d_incorrect_order_triggers
 
     subroutine test_2d_correct_order_ok()
@@ -77,7 +77,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P001", .false., &
                                         "innermost loop varies leftmost index")
-        print *, "  + 2D correct ordering ok"
+        print *, "[OK] 2D correct ordering ok"
     end subroutine test_2d_correct_order_ok
 
     subroutine test_2d_incorrect_order_under_if_triggers()
@@ -110,7 +110,7 @@ contains
                                         "inner loop nested under if triggers")
         call assert_diagnostic_location(diagnostics, "P001", 9, 28, &
                                         "P001 should point at array reference")
-        print *, "  + 2D incorrect ordering under if triggers"
+        print *, "[OK] 2D incorrect ordering under if triggers"
     end subroutine test_2d_incorrect_order_under_if_triggers
 
     subroutine test_3d_incorrect_order_triggers()
@@ -143,7 +143,7 @@ contains
                                         "3D incorrect ordering triggers")
         call assert_diagnostic_location(diagnostics, "P001", 9, 26, &
                                         "P001 should point at array reference")
-        print *, "  + 3D incorrect ordering triggers"
+        print *, "[OK] 3D incorrect ordering triggers"
     end subroutine test_3d_incorrect_order_triggers
 
     subroutine test_rhs_array_read_triggers()
@@ -175,7 +175,7 @@ contains
                                         "array reads should be checked")
         call assert_diagnostic_location(diagnostics, "P001", 9, 28, &
                                         "P001 should point at array reference")
-        print *, "  + RHS array read triggers"
+        print *, "[OK] RHS array read triggers"
     end subroutine test_rhs_array_read_triggers
 
     subroutine test_non_array_call_ok()
@@ -209,7 +209,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P001", .false., &
                                         "function call should not be flagged")
-        print *, "  + Function call not flagged"
+        print *, "[OK] Function call not flagged"
     end subroutine test_non_array_call_ok
 
 end program test_rule_p001_column_major_access

--- a/test/test_rule_p002_loop_ordering.f90
+++ b/test/test_rule_p002_loop_ordering.f90
@@ -15,7 +15,7 @@ program test_rule_p002_loop_ordering
     ! Test 2: Row-major efficient ordering (should not trigger)
     call test_row_major_efficient()
 
-    print *, "All P002 tests passed!"
+    print *, "[OK] All P002 tests passed!"
 
 contains
 
@@ -49,7 +49,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P002", .true., &
                                         "inefficient loop ordering should be flagged")
-        print *, "  + Column-major inefficient ordering"
+        print *, "[OK] Column-major inefficient ordering"
 
     end subroutine test_column_major_inefficient
 
@@ -83,7 +83,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P002", .false., &
                                         "efficient loop ordering should not be flagged")
-        print *, "  + Row-major efficient ordering"
+        print *, "[OK] Row-major efficient ordering"
 
     end subroutine test_row_major_efficient
 

--- a/test/test_rule_p003_array_temporaries.f90
+++ b/test/test_rule_p003_array_temporaries.f90
@@ -12,7 +12,7 @@ program test_rule_p003_array_temporaries
     call test_whole_array_expression_triggers()
     call test_elemental_loop_is_ok()
 
-    print *, "All P003 tests passed!"
+    print *, "[OK] All P003 tests passed!"
 
 contains
 
@@ -36,7 +36,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P003", .true., &
                                         "whole-array expression should be flagged")
-        print *, "  + Whole-array expression"
+        print *, "[OK] Whole-array expression"
     end subroutine test_whole_array_expression_triggers
 
     subroutine test_elemental_loop_is_ok()
@@ -62,7 +62,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P003", .false., &
                                         "element-wise loop should not be flagged")
-        print *, "  + Element-wise loop"
+        print *, "[OK] Element-wise loop"
     end subroutine test_elemental_loop_is_ok
 
 end program test_rule_p003_array_temporaries

--- a/test/test_rule_p004_pure_elemental.f90
+++ b/test/test_rule_p004_pure_elemental.f90
@@ -12,7 +12,7 @@ program test_rule_p004_pure_elemental
     call test_missing_pure_triggers()
     call test_already_pure_is_ok()
 
-    print *, "All P004 tests passed!"
+    print *, "[OK] All P004 tests passed!"
 
 contains
 
@@ -44,7 +44,7 @@ contains
             .true., &
             "missing pure on side-effect-free function should be "// &
             "flagged")
-        print *, "  + Missing pure"
+        print *, "[OK] Missing pure"
     end subroutine test_missing_pure_triggers
 
     subroutine test_already_pure_is_ok()
@@ -71,7 +71,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P004", .false., &
                                         "pure function should not be flagged")
-        print *, "  + Already pure"
+        print *, "[OK] Already pure"
     end subroutine test_already_pure_is_ok
 
 end program test_rule_p004_pure_elemental

--- a/test/test_rule_p005_string_operations.f90
+++ b/test/test_rule_p005_string_operations.f90
@@ -12,7 +12,7 @@ program test_rule_p005_string_operations
     call test_loop_concatenation_triggers()
     call test_no_concatenation_is_ok()
 
-    print *, "All P005 tests passed!"
+    print *, "[OK] All P005 tests passed!"
 
 contains
 
@@ -43,7 +43,7 @@ contains
             "P005", &
             .true., &
             "string concatenation in loop should be flagged")
-        print *, "  + Loop concatenation"
+        print *, "[OK] Loop concatenation"
     end subroutine test_loop_concatenation_triggers
 
     subroutine test_no_concatenation_is_ok()
@@ -70,7 +70,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P005", .false., &
                                         "no concatenation should not be flagged")
-        print *, "  + No concatenation"
+        print *, "[OK] No concatenation"
     end subroutine test_no_concatenation_is_ok
 
 end program test_rule_p005_string_operations

--- a/test/test_rule_p006_loop_allocations.f90
+++ b/test/test_rule_p006_loop_allocations.f90
@@ -12,7 +12,7 @@ program test_rule_p006_loop_allocations
     call test_allocate_inside_loop_triggers()
     call test_allocate_outside_loop_is_ok()
 
-    print *, "All P006 tests passed!"
+    print *, "[OK] All P006 tests passed!"
 
 contains
 
@@ -41,7 +41,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P006", .true., &
                                         "allocate inside loop should be flagged")
-        print *, "  + Allocate inside loop"
+        print *, "[OK] Allocate inside loop"
     end subroutine test_allocate_inside_loop_triggers
 
     subroutine test_allocate_outside_loop_is_ok()
@@ -69,7 +69,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P006", .false., &
                                         "allocate outside loop should not be flagged")
-        print *, "  + Allocate outside loop"
+        print *, "[OK] Allocate outside loop"
     end subroutine test_allocate_outside_loop_is_ok
 
 end program test_rule_p006_loop_allocations

--- a/test/test_rule_p007_mixed_precision.f90
+++ b/test/test_rule_p007_mixed_precision.f90
@@ -12,7 +12,7 @@ program test_rule_p007_mixed_precision
     call test_mixed_precision_triggers()
     call test_consistent_precision_is_ok()
 
-    print *, "All P007 tests passed!"
+    print *, "[OK] All P007 tests passed!"
 
 contains
 
@@ -38,7 +38,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P007", .true., &
                                         "mixed precision binary op should be flagged")
-        print *, "  + Mixed precision"
+        print *, "[OK] Mixed precision"
     end subroutine test_mixed_precision_triggers
 
     subroutine test_consistent_precision_is_ok()
@@ -63,7 +63,7 @@ contains
 
         call assert_has_diagnostic_code(diagnostics, "P007", .false., &
                                         "consistent precision should not be flagged")
-        print *, "  + Consistent precision"
+        print *, "[OK] Consistent precision"
     end subroutine test_consistent_precision_is_ok
 
 end program test_rule_p007_mixed_precision

--- a/test/test_rule_registry.f90
+++ b/test/test_rule_registry.f90
@@ -20,7 +20,7 @@ program test_rule_registry
     ! Test 4: Find rule by code
     call test_find_by_code()
     
-    print *, "All rule registry tests passed!"
+    print *, "[OK] All rule registry tests passed!"
     
 contains
     
@@ -41,7 +41,7 @@ contains
             error stop "Failed: should discover built-in rules"
         end if
         
-        print *, "  OK Rule discovery found", final_count, "rules"
+        print *, "[OK] Rule discovery found", final_count, "rules"
     end subroutine test_rule_discovery
     
     subroutine test_rule_filtering()
@@ -71,7 +71,7 @@ contains
             end if
         end do
         
-        print *, "  OK Rule filtering by selection"
+        print *, "[OK] Rule filtering by selection"
     end subroutine test_rule_filtering
     
     subroutine test_execution_order()
@@ -98,7 +98,7 @@ contains
             end if
         end do
         
-        print *, "  OK Rule execution order"
+        print *, "[OK] Rule execution order"
     end subroutine test_execution_order
     
     subroutine test_find_by_code()
@@ -126,7 +126,7 @@ contains
             error stop "Failed: should not find non-existent rule"
         end if
         
-        print *, "  OK Find rule by code"
+        print *, "[OK] Find rule by code"
     end subroutine test_find_by_code
     
 end program test_rule_registry

--- a/test/test_style_guides.f90
+++ b/test/test_style_guides.f90
@@ -6,7 +6,7 @@ program test_style_guides
     type(formatter_engine_t) :: formatter
     integer :: total_tests, passed_tests
     
-    print *, "=== Standard Style Guides Test Suite (RED Phase) ==="
+    print *, "=== Standard Style Guides Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -29,7 +29,7 @@ program test_style_guides
     if (passed_tests == total_tests) then
         print *, "[OK] All style guide tests passed!"
     else
-        print *, "[FAIL] Some style guide tests failed (expected in RED phase)"
+        print *, "[FAIL] Some style guide tests failed"
     end if
     
 contains
@@ -341,17 +341,17 @@ contains
         call formatter%format_source(input, formatted_code, error_msg)
         
         if (error_msg /= "") then
-            print *, "  FAIL: ", test_name, " - Error: ", error_msg
+            print *, "[FAIL] ", test_name, " - Error: ", error_msg
             return
         end if
         
         ! For now, just check that formatting completed without error
         ! In the GREEN phase, we'll implement proper style validation
         if (len(formatted_code) > 0) then
-            print *, "  PASS: ", test_name, " (", style_name, " style)"
+            print *, "[OK] ", test_name, " (", style_name, " style)"
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - Empty output"
+            print *, "[FAIL] ", test_name, " - Empty output"
         end if
         
     end subroutine run_style_test
@@ -367,10 +367,10 @@ contains
         ! For now, just check that detection completes
         ! In the GREEN phase, we'll implement actual detection logic
         if (len(detected_style) > 0) then
-            print *, "  PASS: ", test_name, " - Detected: ", detected_style
+            print *, "[OK] ", test_name, " - Detected: ", detected_style
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name, " - No style detected"
+            print *, "[FAIL] ", test_name, " - No style detected"
         end if
         
     end subroutine run_detection_test

--- a/test/test_toml_parsing.f90
+++ b/test/test_toml_parsing.f90
@@ -11,7 +11,7 @@ program test_toml_parsing
     ! Test 2: Invalid configuration handling  
     call test_invalid_config()
     
-    print *, "All namelist parsing tests passed!"
+    print *, "[OK] All namelist parsing tests passed!"
     
 contains
     
@@ -66,7 +66,7 @@ contains
             error stop "Failed: output_format should be json"
         end if
         
-        print *, "  OK Basic configuration parsing"
+        print *, "[OK] Basic configuration parsing"
     end subroutine test_basic_config
     
     
@@ -90,7 +90,7 @@ contains
             error stop "Failed: error message should mention configuration"
         end if
         
-        print *, "  OK Invalid configuration handling"
+        print *, "[OK] Invalid configuration handling"
     end subroutine test_invalid_config
     
 end program test_toml_parsing

--- a/test/test_tool_integration.f90
+++ b/test/test_tool_integration.f90
@@ -13,7 +13,7 @@ program test_tool_integration
     
     integer :: total_tests, passed_tests
     
-    print *, "=== Tool Integration Test Suite (RED Phase) ==="
+    print *, "=== Tool Integration Test Suite ==="
     
     total_tests = 0
     passed_tests = 0
@@ -35,7 +35,7 @@ program test_tool_integration
     if (passed_tests == total_tests) then
         print *, "[OK] All tool integration tests passed!"
     else
-        print *, "[FAIL] Some tests failed (expected in RED phase)"
+        print *, "[FAIL] Some tests failed"
     end if
     
 contains
@@ -237,10 +237,10 @@ contains
         success = test_proc()
         
         if (success .eqv. should_succeed) then
-            print *, "  PASS: ", test_name
+            print *, "[OK] ", test_name
             passed_tests = passed_tests + 1
         else
-            print *, "  FAIL: ", test_name
+            print *, "[FAIL] ", test_name
         end if
         
     end subroutine run_integration_test

--- a/test/test_user_feedback_demo.f90
+++ b/test/test_user_feedback_demo.f90
@@ -57,7 +57,7 @@ contains
     
     subroutine simulate_positive_feedback()
         print *, ""
-        print *, "--- Simulating Positive User Feedback ---"
+        print *, "=== Simulating Positive User Feedback ==="
         
         feedback = create_user_feedback()
         feedback%quality_rating = 9
@@ -80,7 +80,7 @@ contains
     
     subroutine simulate_constructive_feedback()
         print *, ""
-        print *, "--- Simulating Constructive User Feedback ---"
+        print *, "=== Simulating Constructive User Feedback ==="
         
         feedback = create_user_feedback()
         feedback%quality_rating = 6
@@ -103,7 +103,7 @@ contains
     
     subroutine simulate_negative_feedback()
         print *, ""
-        print *, "--- Simulating Critical User Feedback ---"
+        print *, "=== Simulating Critical User Feedback ==="
         
         feedback = create_user_feedback()
         feedback%quality_rating = 3
@@ -141,7 +141,7 @@ contains
         
         print *, "Based on collected feedback, here are key insights:"
         do i = 1, size(insights)
-            print *, "  - ", trim(insights(i))
+            print *, "  ", i, ". ", trim(insights(i))
         end do
         
         print *, ""


### PR DESCRIPTION
Fixes #173

Standardizes test output status markers to a single ASCII convention:
- Per-test/per-suite status lines now use `[OK]`, `[FAIL]`, `[WARN]` prefixes.
- Removes mixed `PASS`, `OK`, `+`, `-` markers from test status output.

## Verification

```bash
fpm test 2>&1 | tee /tmp/fluff-fpm-test.log
```

Output excerpt:

```text
 Success rate:    100.00000000000000      %
STOP 0
 Testing P001: Column-major array access rule...
 [OK] 2D incorrect ordering triggers
 [OK] 2D incorrect ordering under if triggers
 [OK] 2D correct ordering ok
 [OK] 3D incorrect ordering triggers
 [OK] RHS array read triggers
 [OK] Function call not flagged
 [OK] All P001 tests passed!
 Testing P004: Missing pure/elemental declarations rule...
 [OK] Missing pure
 [OK] Already pure
 [OK] All P004 tests passed!
```

```bash
rg -n "PASS:|FAIL:" /tmp/fluff-fpm-test.log
```

## Artifacts

- `/tmp/fluff-fpm-test.log`
