### PR TITLE
fix: add non-interactive clean helper (fixes #122)

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Non-interactive build artifact cleanup for CI and automated contexts.
+# Removes the build/ directory without prompting (unlike fpm clean).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build"
+
+if [ -d "$BUILD_DIR" ]; then
+    rm -rf "$BUILD_DIR"
+    echo "Removed $BUILD_DIR"
+else
+    echo "Nothing to clean: $BUILD_DIR does not exist"
+fi


### PR DESCRIPTION
## Summary
- Adds scripts/clean.sh for non-interactive build artifact cleanup
- Avoids EOF errors from fpm clean in CI/automated contexts

## Test plan
- [x] Script removes build/ directory safely
- [x] fpm test passes

Generated with [Claude Code](https://claude.com/claude-code)