### PR TITLE
fix: share token->source_range conversion helpers (fixes #153)

### DIFF
--- a/src/fluff_rules/shared/fluff_token_helpers.f90
+++ b/src/fluff_rules/shared/fluff_token_helpers.f90
@@ -1,0 +1,97 @@
+module fluff_token_helpers
+    use fluff_core, only: source_range_t
+    use fortfront, only: token_t
+    use lexer_token_types, only: TK_NEWLINE, TK_WHITESPACE
+    implicit none
+    private
+
+    public :: token_location
+    public :: token_location_point
+    public :: first_nontrivia_in_line
+    public :: next_nontrivia_same_line
+    public :: next_nontrivia
+
+contains
+
+    pure function token_location(tok) result(location)
+        type(token_t), intent(in) :: tok
+        type(source_range_t) :: location
+
+        integer :: end_col
+
+        location%start%line = tok%line
+        location%start%column = tok%column
+        location%end%line = tok%line
+        end_col = tok%column
+        if (allocated(tok%text)) end_col = end_col + len(tok%text) - 1
+        location%end%column = end_col
+    end function token_location
+
+    pure function token_location_point(tok) result(location)
+        type(token_t), intent(in) :: tok
+        type(source_range_t) :: location
+
+        location%start%line = tok%line
+        location%start%column = tok%column
+        location%end%line = tok%line
+        location%end%column = tok%column
+    end function token_location_point
+
+    integer function first_nontrivia_in_line(tokens, start_idx) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_idx
+
+        integer :: line
+        integer :: i
+
+        idx = 0
+        line = tokens(start_idx)%line
+        do i = start_idx, size(tokens)
+            if (tokens(i)%line /= line) exit
+            if (tokens(i)%kind == TK_NEWLINE) cycle
+            if (tokens(i)%kind == TK_WHITESPACE) cycle
+            idx = i
+            return
+        end do
+    end function first_nontrivia_in_line
+
+    integer function next_nontrivia_same_line(tokens, start_idx) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_idx
+
+        integer :: line
+        integer :: i
+
+        idx = 0
+        if (start_idx <= 0) return
+        if (start_idx > size(tokens)) return
+        line = tokens(start_idx)%line
+
+        do i = start_idx, size(tokens)
+            if (tokens(i)%line /= line) exit
+            if (tokens(i)%kind == TK_NEWLINE) cycle
+            if (tokens(i)%kind == TK_WHITESPACE) cycle
+            idx = i
+            return
+        end do
+    end function next_nontrivia_same_line
+
+    integer function next_nontrivia(tokens, start_idx) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_idx
+
+        integer :: i
+
+        idx = 0
+        if (start_idx <= 0) return
+        if (start_idx > size(tokens)) return
+
+        do i = start_idx, size(tokens)
+            if (tokens(i)%kind == TK_NEWLINE) cycle
+            if (tokens(i)%kind == TK_WHITESPACE) cycle
+            idx = i
+            return
+        end do
+    end function next_nontrivia
+
+end module fluff_token_helpers

--- a/src/fluff_rules/style/fluff_rule_f010.f90
+++ b/src/fluff_rules/style/fluff_rule_f010.f90
@@ -4,6 +4,8 @@ module fluff_rule_f010
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
     use fluff_rule_file_context, only: current_filename
+    use fluff_token_helpers, only: token_location, first_nontrivia_in_line, &
+                                   next_nontrivia_same_line
     use fortfront, only: comment_node, goto_node, token_t, tokenize_core_with_trivia
     use lexer_token_types, only: TK_KEYWORD, TK_NEWLINE, TK_NUMBER, TK_OPERATOR, &
                                  TK_WHITESPACE, TK_COMMENT
@@ -214,57 +216,5 @@ contains
             if (tokens(j)%text == ")") idx = j
         end do
     end function find_last_close_paren
-
-    integer function first_nontrivia_in_line(tokens, start_idx) result(idx)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_idx
-
-        integer :: line
-        integer :: i
-
-        idx = 0
-        line = tokens(start_idx)%line
-        do i = start_idx, size(tokens)
-            if (tokens(i)%line /= line) exit
-            if (tokens(i)%kind == TK_NEWLINE) cycle
-            if (tokens(i)%kind == TK_WHITESPACE) cycle
-            idx = i
-            return
-        end do
-    end function first_nontrivia_in_line
-
-    integer function next_nontrivia_same_line(tokens, start_idx) result(idx)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_idx
-
-        integer :: line
-        integer :: i
-
-        idx = 0
-        if (start_idx <= 0) return
-        if (start_idx > size(tokens)) return
-        line = tokens(start_idx)%line
-
-        do i = start_idx, size(tokens)
-            if (tokens(i)%line /= line) exit
-            if (tokens(i)%kind == TK_NEWLINE) cycle
-            if (tokens(i)%kind == TK_WHITESPACE) cycle
-            idx = i
-            return
-        end do
-    end function next_nontrivia_same_line
-
-    pure function token_location(tok) result(location)
-        type(token_t), intent(in) :: tok
-        type(source_range_t) :: location
-        integer :: end_col
-
-        location%start%line = tok%line
-        location%start%column = tok%column
-        location%end%line = tok%line
-        end_col = tok%column
-        if (allocated(tok%text)) end_col = end_col + len(tok%text) - 1
-        location%end%column = end_col
-    end function token_location
 
 end module fluff_rule_f010

--- a/src/fluff_rules/style/fluff_rule_f013.f90
+++ b/src/fluff_rules/style/fluff_rule_f013.f90
@@ -1,9 +1,9 @@
 module fluff_rule_f013
     use fluff_ast, only: fluff_ast_context_t
-    use fluff_core, only: source_range_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_rule_diagnostic_utils, only: push_diagnostic
     use fluff_rule_file_context, only: current_filename
+    use fluff_token_helpers, only: token_location_point
     use fortfront, only: token_t, tokenize_core_with_trivia
     use lexer_token_types, only: TK_OPERATOR
     implicit none
@@ -44,7 +44,7 @@ contains
                                      code="F013", &
                                      message="Multiple statements per line", &
                                      file_path=current_filename, &
-                                     location=token_location(tokens(i)), &
+                                     location=token_location_point(tokens(i)), &
                                      severity=SEVERITY_WARNING))
             end do
         end if
@@ -52,15 +52,5 @@ contains
         allocate (violations(violation_count))
         if (violation_count > 0) violations = tmp(1:violation_count)
     end subroutine check_f013_multiple_statements
-
-    pure function token_location(tok) result(location)
-        type(token_t), intent(in) :: tok
-        type(source_range_t) :: location
-
-        location%start%line = tok%line
-        location%start%column = tok%column
-        location%end%line = tok%line
-        location%end%column = tok%column
-    end function token_location
 
 end module fluff_rule_f013

--- a/src/fluff_rules/style/fluff_rule_f015.f90
+++ b/src/fluff_rules/style/fluff_rule_f015.f90
@@ -4,6 +4,8 @@ module fluff_rule_f015
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
     use fluff_rule_file_context, only: current_filename
+    use fluff_token_helpers, only: token_location, first_nontrivia_in_line, &
+                                   next_nontrivia_same_line, next_nontrivia
     use fortfront, only: token_t, tokenize_core_with_trivia
     use lexer_token_types, only: TK_KEYWORD, TK_NEWLINE, TK_NUMBER, TK_OPERATOR, &
                                  TK_WHITESPACE
@@ -485,63 +487,6 @@ contains
         end do
     end function is_label_referenced
 
-    integer function first_nontrivia_in_line(tokens, start_idx) result(idx)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_idx
-
-        integer :: line
-        integer :: i
-
-        idx = 0
-        line = tokens(start_idx)%line
-        do i = start_idx, size(tokens)
-            if (tokens(i)%line /= line) exit
-            if (tokens(i)%kind == TK_NEWLINE) cycle
-            if (tokens(i)%kind == TK_WHITESPACE) cycle
-            idx = i
-            return
-        end do
-    end function first_nontrivia_in_line
-
-    integer function next_nontrivia_same_line(tokens, start_idx) result(idx)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_idx
-
-        integer :: line
-        integer :: i
-
-        idx = 0
-        if (start_idx <= 0) return
-        if (start_idx > size(tokens)) return
-        line = tokens(start_idx)%line
-
-        do i = start_idx, size(tokens)
-            if (tokens(i)%line /= line) exit
-            if (tokens(i)%kind == TK_NEWLINE) cycle
-            if (tokens(i)%kind == TK_WHITESPACE) cycle
-            idx = i
-            return
-        end do
-    end function next_nontrivia_same_line
-
-    integer function next_nontrivia(tokens, start_idx) result(idx)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_idx
-
-        integer :: i
-
-        idx = 0
-        if (start_idx <= 0) return
-        if (start_idx > size(tokens)) return
-
-        do i = start_idx, size(tokens)
-            if (tokens(i)%kind == TK_NEWLINE) cycle
-            if (tokens(i)%kind == TK_WHITESPACE) cycle
-            idx = i
-            return
-        end do
-    end function next_nontrivia
-
     subroutine parse_label(text, label, ok)
         character(len=*), intent(in) :: text
         integer, intent(out) :: label
@@ -571,18 +516,5 @@ contains
         tmp(size(values) + 1) = value
         call move_alloc(tmp, values)
     end subroutine push_int_unique
-
-    pure function token_location(tok) result(location)
-        type(token_t), intent(in) :: tok
-        type(source_range_t) :: location
-        integer :: end_col
-
-        location%start%line = tok%line
-        location%start%column = tok%column
-        location%end%line = tok%line
-        end_col = tok%column
-        if (allocated(tok%text)) end_col = end_col + len(tok%text) - 1
-        location%end%column = end_col
-    end function token_location
 
 end module fluff_rule_f015


### PR DESCRIPTION
## Summary
- Create `fluff_token_helpers` module in `src/fluff_rules/shared/` centralizing token utilities
- Provide `token_location` (span) and `token_location_point` (single position) for token to source_range_t conversion
- Provide `first_nontrivia_in_line`, `next_nontrivia_same_line`, and `next_nontrivia` for token scanning
- Refactor `fluff_rule_f010`, `fluff_rule_f013`, and `fluff_rule_f015` to use shared module
- Net reduction: 134 lines removed, 103 lines added (31 lines saved)

## Test plan
- [x] All existing tests pass (`fpm test`)
- [x] No behavior change - pure refactoring for code reuse
- [x] Applied fprettify with 88-column, 4-space indent formatting

Fixes #153

Generated with [Claude Code](https://claude.com/claude-code)