### PR TITLE
fix: make tab width configurable for F003 (fixes #132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,19 @@ fluff check --output-format json src/
   fix = .true.
   show_fixes = .true.
   line_length = 100
+  tab_width = 4
   target_version = "2018"
   output_format = "json"
 /
 ```
+
+Configuration options:
+- `fix`: Enable automatic fixing of violations (default: `.false.`)
+- `show_fixes`: Show suggested fixes without applying (default: `.false.`)
+- `line_length`: Maximum line length, 40-200 (default: `88`)
+- `tab_width`: Tab width for visual column calculation, 1-16 (default: `4`)
+- `target_version`: Target Fortran version: "2008", "2018", "2023" (default: `"2018"`)
+- `output_format`: Output format: "text", "json", "sarif" (default: `"text"`)
 
 ## 📋 Available Rules
 

--- a/fluff.toml
+++ b/fluff.toml
@@ -1,3 +1,12 @@
-# Configuration placeholder
-# TOML configuration is not yet implemented
-# Use command-line arguments instead
+# fluff configuration file
+# See README.md for documentation on available options
+
+# Using namelist format for configuration
+&fluff_config
+  fix = .false.
+  show_fixes = .false.
+  line_length = 88
+  tab_width = 4
+  target_version = "2018"
+  output_format = "text"
+/

--- a/src/fluff_config/fluff_config.f90
+++ b/src/fluff_config/fluff_config.f90
@@ -3,7 +3,7 @@ module fluff_config
     use fluff_core
     implicit none
     private
-    
+
     ! Configuration override type for CLI arguments
     type, public :: config_override_t
         logical :: has_fix = .false.
@@ -13,13 +13,13 @@ module fluff_config
         logical :: has_output_format = .false.
         character(len=:), allocatable :: output_format
     end type config_override_t
-    
+
     ! Per-file ignore patterns
     type, public :: per_file_ignore_t
         character(len=:), allocatable :: pattern    ! File glob pattern
         character(len=:), allocatable :: rules(:)   ! Rules to ignore
     end type per_file_ignore_t
-    
+
     ! Rule selection configuration
     type, public :: rule_selection_t
         character(len=:), allocatable :: select(:)        ! Rules to enable
@@ -29,12 +29,13 @@ module fluff_config
     contains
         procedure :: is_rule_enabled => selection_is_rule_enabled
     end type rule_selection_t
-    
+
     ! Configuration type
     type, public :: fluff_config_t
         logical :: fix = .false.
         logical :: show_fixes = .false.
         integer :: line_length = 88
+        integer :: tab_width = 4
         character(len=:), allocatable :: target_version   ! "2008", "2018", "2023"
         character(len=:), allocatable :: output_format    ! "text", "json", "sarif"
         type(rule_selection_t) :: rules
@@ -45,110 +46,113 @@ module fluff_config
         procedure :: validate => config_validate
         procedure :: merge => config_merge
     end type fluff_config_t
-    
+
     ! Public procedures
     public :: create_default_config
     public :: load_config
     public :: load_config_profile
     public :: get_config_schema_doc
-    
+
 contains
-    
+
     ! Create default configuration
     function create_default_config() result(config)
         type(fluff_config_t) :: config
-        
+
         config%fix = .false.
         config%show_fixes = .false.
         config%line_length = 88
+        config%tab_width = 4
         config%target_version = "2018"
         config%output_format = "text"
-        
+
         ! Default rule selection - enable all style rules
-        allocate(character(len=4) :: config%rules%select(1))
+        allocate (character(len=4) :: config%rules%select(1))
         config%rules%select(1) = "F"  ! All F-prefixed rules
-        
+
     end function create_default_config
-    
+
     ! Load configuration from file and CLI
     function load_config(config_file) result(config)
         character(len=*), intent(in), optional :: config_file
         type(fluff_config_t) :: config
         character(len=:), allocatable :: error_msg
-        
+
         ! Start with defaults
         config = create_default_config()
-        
+
         ! Load from file if provided
         if (present(config_file)) then
             call config%from_file(config_file)
         end if
-        
+
         ! Validate final configuration
         if (.not. config%validate(error_msg)) then
             ! Reset to defaults if invalid
             config = create_default_config()
         end if
-        
+
     end function load_config
-    
+
     ! Load configuration from TOML file
     subroutine config_from_file(this, filename)
         class(fluff_config_t), intent(inout) :: this
         character(len=*), intent(in) :: filename
-        
+
         ! Read file contents and parse as TOML string
         integer :: unit, iostat
         character(len=1000) :: line
         character(len=:), allocatable :: toml_content, error_msg
-        
+
         toml_content = ""
-        
-        open(newunit=unit, file=filename, status='old', action='read', iostat=iostat)
+
+        open (newunit=unit, file=filename, status='old', action='read', iostat=iostat)
         if (iostat /= 0) return  ! File doesn't exist or can't be read
-        
+
         do
-            read(unit, '(A)', iostat=iostat) line
+            read (unit, '(A)', iostat=iostat) line
             if (iostat /= 0) exit
-            toml_content = toml_content // trim(line) // new_line('a')
+            toml_content = toml_content//trim(line)//new_line('a')
         end do
-        close(unit)
-        
+        close (unit)
+
         call this%from_toml_string(toml_content, error_msg)
-        
+
     end subroutine config_from_file
-    
-    ! Load configuration from namelist string  
+
+    ! Load configuration from namelist string
     subroutine config_from_toml_string(this, config_str, error_msg)
         class(fluff_config_t), intent(inout) :: this
         character(len=*), intent(in) :: config_str
         character(len=:), allocatable, intent(out) :: error_msg
-        
+
         integer :: unit, iostat
         logical :: fix, show_fixes
-        integer :: line_length
+        integer :: line_length, tab_width
         character(len=20) :: target_version, output_format
-        
+
         ! Namelist declaration for main config
-        namelist /fluff_config/ fix, show_fixes, line_length, target_version, output_format
-        
+        namelist /fluff_config/ fix, show_fixes, line_length, tab_width, &
+            target_version, output_format
+
         error_msg = ""
-        
+
         ! Set defaults
         fix = this%fix
         show_fixes = this%show_fixes
         line_length = this%line_length
+        tab_width = this%tab_width
         target_version = ""
         output_format = ""
         if (allocated(this%target_version)) target_version = this%target_version
         if (allocated(this%output_format)) output_format = this%output_format
-        
+
         ! Write config string to temporary unit and read namelist
-        open(newunit=unit, status='scratch', form='formatted', action='readwrite')
-        write(unit, '(A)') config_str
-        rewind(unit)
-        
-        read(unit, nml=fluff_config, iostat=iostat)
+        open (newunit=unit, status='scratch', form='formatted', action='readwrite')
+        write (unit, '(A)') config_str
+        rewind (unit)
+
+        read (unit, nml=fluff_config, iostat=iostat)
         if (iostat /= 0) then
             if (iostat > 0) then
                 error_msg = "Invalid configuration format"
@@ -159,25 +163,26 @@ contains
             this%fix = fix
             this%show_fixes = show_fixes
             this%line_length = line_length
+            this%tab_width = tab_width
             if (len_trim(target_version) > 0) this%target_version = trim(target_version)
             if (len_trim(output_format) > 0) this%output_format = trim(output_format)
         end if
-        
-        close(unit)
-        
+
+        close (unit)
+
     end subroutine config_from_toml_string
-    
+
     ! Split TOML string into lines
     subroutine split_lines(text, lines, num_lines)
         character(len=*), intent(in) :: text
         character(len=1000), intent(out) :: lines(:)
         integer, intent(out) :: num_lines
-        
+
         integer :: i, start_pos, end_pos, newline_pos
-        
+
         num_lines = 0
         start_pos = 1
-        
+
         do while (start_pos <= len(text) .and. num_lines < size(lines))
             ! Find next newline
             newline_pos = index(text(start_pos:), new_line('a'))
@@ -187,23 +192,23 @@ contains
             else
                 end_pos = start_pos + newline_pos - 2
             end if
-            
+
             if (end_pos >= start_pos) then
                 num_lines = num_lines + 1
                 lines(num_lines) = text(start_pos:end_pos)
             end if
-            
+
             if (newline_pos == 0) exit
             start_pos = start_pos + newline_pos
         end do
-        
+
     end subroutine split_lines
-    
+
     ! Apply CLI argument overrides
     subroutine config_from_cli_args(this, cli_args)
         class(fluff_config_t), intent(inout) :: this
         class(*), intent(in) :: cli_args
-        
+
         ! Handle config_override_t type
         select type (args => cli_args)
         type is (config_override_t)
@@ -211,11 +216,11 @@ contains
             if (args%has_fix) then
                 this%fix = args%fix
             end if
-            
+
             if (args%has_show_fixes) then
                 this%show_fixes = args%show_fixes
             end if
-            
+
             if (args%has_output_format .and. allocated(args%output_format)) then
                 this%output_format = args%output_format
             end if
@@ -225,28 +230,37 @@ contains
             this%fix = .true.
             this%output_format = "json"
         end select
-        
+
     end subroutine config_from_cli_args
-    
+
     ! Validate configuration
     function config_validate(this, error_msg) result(valid)
         class(fluff_config_t), intent(in) :: this
         character(len=:), allocatable, intent(out), optional :: error_msg
         logical :: valid
         character(len=:), allocatable :: invalid_code
-        
+
         valid = .true.
         if (present(error_msg)) error_msg = ""
-        
+
         ! Validate line length
         if (this%line_length < 40 .or. this%line_length > 200) then
             valid = .false.
             if (present(error_msg)) then
-                error_msg = "line-length must be between 40 and 200. Valid range: [40, 200]"
+            error_msg = "line-length must be between 40 and 200. Valid range: [40, 200]"
             end if
             return
         end if
-        
+
+        ! Validate tab width
+        if (this%tab_width < 1 .or. this%tab_width > 16) then
+            valid = .false.
+            if (present(error_msg)) then
+                error_msg = "tab-width must be between 1 and 16. Valid range: [1, 16]"
+            end if
+            return
+        end if
+
         ! Validate target version
         if (allocated(this%target_version)) then
             select case (this%target_version)
@@ -255,12 +269,12 @@ contains
             case default
                 valid = .false.
                 if (present(error_msg)) then
-                    error_msg = "invalid target-version: " // this%target_version
+                    error_msg = "invalid target-version: "//this%target_version
                 end if
                 return
             end select
         end if
-        
+
         ! Validate output format
         if (allocated(this%output_format)) then
             select case (this%output_format)
@@ -269,20 +283,20 @@ contains
             case default
                 valid = .false.
                 if (present(error_msg)) then
-                    error_msg = "invalid output-format: " // this%output_format
+                    error_msg = "invalid output-format: "//this%output_format
                 end if
                 return
             end select
         end if
-        
+
         ! Validate rule codes
         if (allocated(this%rules%select)) then
             if (.not. validate_rule_codes(this%rules%select, invalid_code)) then
                 valid = .false.
                 if (present(error_msg)) then
                     if (allocated(invalid_code)) then
-                        error_msg = "invalid rule code in select: " // invalid_code // &
-                                  ". Valid prefixes: F, W, C, P, S or ALL"
+                        error_msg = "invalid rule code in select: "//invalid_code// &
+                                    ". Valid prefixes: F, W, C, P, S or ALL"
                     else
                         error_msg = "invalid rule code in select"
                     end if
@@ -290,28 +304,29 @@ contains
                 return
             end if
         end if
-        
+
     end function config_validate
-    
+
     ! Merge two configurations
     subroutine config_merge(this, base, override)
         class(fluff_config_t), intent(inout) :: this
         type(fluff_config_t), intent(in) :: base
         type(fluff_config_t), intent(in), optional :: override
-        
+
         ! Start with base configuration
         this%fix = base%fix
         this%show_fixes = base%show_fixes
         this%line_length = base%line_length
-        
+        this%tab_width = base%tab_width
+
         if (allocated(base%target_version)) then
             this%target_version = base%target_version
         end if
-        
+
         if (allocated(base%output_format)) then
             this%output_format = base%output_format
         end if
-        
+
         ! Copy base rules
         if (allocated(base%rules%select)) then
             this%rules%select = base%rules%select
@@ -319,21 +334,22 @@ contains
         if (allocated(base%rules%ignore)) then
             this%rules%ignore = base%rules%ignore
         end if
-        
+
         ! Apply overrides if present
         if (present(override)) then
             if (override%fix) this%fix = override%fix
             if (override%show_fixes) this%show_fixes = override%show_fixes
             if (override%line_length /= 88) this%line_length = override%line_length
-            
+            if (override%tab_width /= 4) this%tab_width = override%tab_width
+
             if (allocated(override%target_version)) then
                 this%target_version = override%target_version
             end if
-            
+
             if (allocated(override%output_format)) then
                 this%output_format = override%output_format
             end if
-            
+
             if (allocated(override%rules%select)) then
                 this%rules%select = override%rules%select
             end if
@@ -341,19 +357,19 @@ contains
                 this%rules%ignore = override%rules%ignore
             end if
         end if
-        
+
     end subroutine config_merge
-    
+
     ! Check if a rule is enabled
     function selection_is_rule_enabled(this, rule_code) result(enabled)
         class(rule_selection_t), intent(in) :: this
         character(len=*), intent(in) :: rule_code
         logical :: enabled
-        
+
         integer :: i
-        
+
         enabled = .false.
-        
+
         ! Check if rule matches any select pattern
         if (allocated(this%select)) then
             do i = 1, size(this%select)
@@ -363,7 +379,7 @@ contains
                 end if
             end do
         end if
-        
+
         ! Check if rule is explicitly ignored
         if (enabled .and. allocated(this%ignore)) then
             do i = 1, size(this%ignore)
@@ -373,90 +389,90 @@ contains
                 end if
             end do
         end if
-        
+
     end function selection_is_rule_enabled
-    
+
     ! Check if rule code matches pattern
     function rule_matches_pattern(rule_code, pattern) result(matches)
         character(len=*), intent(in) :: rule_code
         character(len=*), intent(in) :: pattern
         logical :: matches
-        
+
         ! Simple prefix matching for now
         if (len(pattern) <= len(rule_code)) then
             matches = rule_code(1:len(pattern)) == pattern
         else
             matches = .false.
         end if
-        
+
     end function rule_matches_pattern
-    
+
     ! Parse integer value from TOML string
     subroutine parse_int_value(toml_str, key, value, error_msg)
         character(len=*), intent(in) :: toml_str
         character(len=*), intent(in) :: key
         integer, intent(out) :: value
         character(len=:), allocatable, intent(out), optional :: error_msg
-        
+
         integer :: key_pos, eq_pos, end_pos, iostat
         character(len=20) :: num_str
-        
+
         if (present(error_msg)) error_msg = ""
-        
-        key_pos = index(toml_str, key // " =")
+
+        key_pos = index(toml_str, key//" =")
         if (key_pos == 0) return
-        
+
         eq_pos = key_pos + len(key) + 2
-        
+
         ! Skip whitespace
         do while (eq_pos <= len(toml_str) .and. toml_str(eq_pos:eq_pos) == " ")
             eq_pos = eq_pos + 1
         end do
-        
+
         ! Check for quoted string (invalid for integer)
         if (eq_pos <= len(toml_str) .and. toml_str(eq_pos:eq_pos) == '"') then
             if (present(error_msg)) then
-                error_msg = key // " must be a number"
+                error_msg = key//" must be a number"
             end if
             return
         end if
-        
+
         end_pos = eq_pos
-        
+
         ! Find end of number
         do while (end_pos <= len(toml_str))
             if (scan(toml_str(end_pos:end_pos), "0123456789") == 0) exit
             end_pos = end_pos + 1
         end do
-        
+
         if (end_pos > eq_pos) then
-            num_str = toml_str(eq_pos:end_pos-1)
-            read(num_str, *, iostat=iostat) value
+            num_str = toml_str(eq_pos:end_pos - 1)
+            read (num_str, *, iostat=iostat) value
             if (iostat /= 0 .and. present(error_msg)) then
-                error_msg = "Invalid number for " // key
+                error_msg = "Invalid number for "//key
             end if
         end if
-        
+
     end subroutine parse_int_value
-    
+
     ! Parse string value from TOML string
     subroutine parse_string_value(toml_str, key, value)
         character(len=*), intent(in) :: toml_str
         character(len=*), intent(in) :: key
         character(len=:), allocatable, intent(out) :: value
-        
+
         integer :: key_pos, start_pos, end_pos
-        
-        key_pos = index(toml_str, key // " =")
+
+        key_pos = index(toml_str, key//" =")
         if (key_pos == 0) return
-        
+
         start_pos = key_pos + len(key) + 2
-        
+
         ! Skip whitespace
         do while (start_pos <= len(toml_str) .and. toml_str(start_pos:start_pos) == " ")
             start_pos = start_pos + 1
         end do
-        
+
         ! Find quoted string
         if (toml_str(start_pos:start_pos) == '"') then
             start_pos = start_pos + 1
@@ -465,68 +481,68 @@ contains
                 value = toml_str(start_pos:start_pos + end_pos - 2)
             end if
         end if
-        
+
     end subroutine parse_string_value
-    
+
     ! Parse rule selection from TOML string
     subroutine parse_rule_selection(toml_str, rules, error_msg)
         character(len=*), intent(in) :: toml_str
         type(rule_selection_t), intent(inout) :: rules
         character(len=:), allocatable, intent(out) :: error_msg
-        
+
         ! Simple parsing for arrays
         if (index(toml_str, 'select = ["F", "W"]') > 0) then
-            if (allocated(rules%select)) deallocate(rules%select)
-            allocate(character(len=1) :: rules%select(2))
+            if (allocated(rules%select)) deallocate (rules%select)
+            allocate (character(len=1) :: rules%select(2))
             rules%select(1) = "F"
             rules%select(2) = "W"
         end if
-        
+
         if (index(toml_str, 'ignore = ["F001", "W002"]') > 0) then
-            if (allocated(rules%ignore)) deallocate(rules%ignore)
-            allocate(character(len=4) :: rules%ignore(2))
+            if (allocated(rules%ignore)) deallocate (rules%ignore)
+            allocate (character(len=4) :: rules%ignore(2))
             rules%ignore(1) = "F001"
             rules%ignore(2) = "W002"
         end if
-        
+
         if (index(toml_str, 'extend-select = ["C"]') > 0) then
-            if (allocated(rules%extend_select)) deallocate(rules%extend_select)
-            allocate(character(len=1) :: rules%extend_select(1))
+            if (allocated(rules%extend_select)) deallocate (rules%extend_select)
+            allocate (character(len=1) :: rules%extend_select(1))
             rules%extend_select(1) = "C"
         end if
-        
+
         ! Parse per-file ignores
         if (index(toml_str, "[tool.fluff.per-file-ignores]") > 0) then
-            if (allocated(rules%per_file_ignores)) deallocate(rules%per_file_ignores)
-            allocate(rules%per_file_ignores(2))
+            if (allocated(rules%per_file_ignores)) deallocate (rules%per_file_ignores)
+            allocate (rules%per_file_ignores(2))
             rules%per_file_ignores(1)%pattern = "test/*.f90"
             if (allocated(rules%per_file_ignores(1)%rules)) deallocate(rules%per_file_ignores(1)%rules)
-            allocate(character(len=4) :: rules%per_file_ignores(1)%rules(1))
+            allocate (character(len=4) :: rules%per_file_ignores(1)%rules(1))
             rules%per_file_ignores(1)%rules(1) = "F001"
-            
+
             rules%per_file_ignores(2)%pattern = "legacy/*.f90"
             if (allocated(rules%per_file_ignores(2)%rules)) deallocate(rules%per_file_ignores(2)%rules)
-            allocate(character(len=1) :: rules%per_file_ignores(2)%rules(2))
+            allocate (character(len=1) :: rules%per_file_ignores(2)%rules(2))
             rules%per_file_ignores(2)%rules(1) = "F"
             rules%per_file_ignores(2)%rules(2) = "W"
         end if
-        
+
     end subroutine parse_rule_selection
-    
+
     ! Validate rule codes
     function validate_rule_codes(codes, invalid_code) result(valid)
         character(len=*), intent(in) :: codes(:)
         character(len=:), allocatable, intent(out), optional :: invalid_code
         logical :: valid
-        
+
         integer :: i
-        
+
         valid = .true.
         if (present(invalid_code)) invalid_code = ""
-        
+
         do i = 1, size(codes)
             ! Check if code starts with valid category
-            select case (codes(i)(1:1))
+            select case (codes(i) (1:1))
             case ("F", "W", "C", "P", "S")
                 ! Valid categories
             case default
@@ -539,17 +555,17 @@ contains
                 end if
             end select
         end do
-        
+
     end function validate_rule_codes
-    
+
     ! Load configuration profile
     function load_config_profile(profile_name) result(config)
         character(len=*), intent(in) :: profile_name
         type(fluff_config_t) :: config
-        
+
         ! Start with defaults
         config = create_default_config()
-        
+
         ! Apply profile settings
         select case (profile_name)
         case ("strict")
@@ -557,76 +573,79 @@ contains
             config%line_length = 80
             config%target_version = "2023"
             ! Enable all rules
-            if (allocated(config%rules%select)) deallocate(config%rules%select)
-            allocate(character(len=3) :: config%rules%select(1))
+            if (allocated(config%rules%select)) deallocate (config%rules%select)
+            allocate (character(len=3) :: config%rules%select(1))
             config%rules%select(1) = "ALL"
-            
+
         case ("performance")
             ! Performance profile - focus on performance rules
-            if (allocated(config%rules%select)) deallocate(config%rules%select)
-            allocate(character(len=1) :: config%rules%select(2))
+            if (allocated(config%rules%select)) deallocate (config%rules%select)
+            allocate (character(len=1) :: config%rules%select(2))
             config%rules%select(1) = "P"  ! Performance rules
             config%rules%select(2) = "C"  ! Correctness rules
-            
+
         case ("legacy")
             ! Legacy profile - more permissive for old code
             config%line_length = 132
             config%target_version = "2008"
             ! Disable some style rules
-            if (allocated(config%rules%ignore)) deallocate(config%rules%ignore)
-            allocate(character(len=1) :: config%rules%ignore(1))
+            if (allocated(config%rules%ignore)) deallocate (config%rules%ignore)
+            allocate (character(len=1) :: config%rules%ignore(1))
             config%rules%ignore(1) = "F"  ! Ignore style rules
-            
+
         case default
             ! Unknown profile - use defaults
         end select
-        
+
     end function load_config_profile
-    
+
     ! Get configuration schema documentation
     function get_config_schema_doc() result(doc)
         character(len=:), allocatable :: doc
-        
-        doc = "# fluff Configuration Schema" // new_line('a') // &
-              new_line('a') // &
-              "Configuration can be specified in `fluff.toml` or `pyproject.toml`:" // new_line('a') // &
-              new_line('a') // &
-              "```toml" // new_line('a') // &
-              "[tool.fluff]" // new_line('a') // &
-              "# Enable automatic fixing of violations" // new_line('a') // &
-              "fix = false" // new_line('a') // &
-              new_line('a') // &
-              "# Show suggested fixes" // new_line('a') // &
-              "show-fixes = false" // new_line('a') // &
-              new_line('a') // &
-              "# Maximum line length (40-200)" // new_line('a') // &
-              "line-length = 88" // new_line('a') // &
-              new_line('a') // &
-              "# Target Fortran version: 2008, 2018, 2023" // new_line('a') // &
-              'target-version = "2018"' // new_line('a') // &
-              new_line('a') // &
-              "# Output format: text, json, sarif" // new_line('a') // &
-              'output-format = "text"' // new_line('a') // &
-              new_line('a') // &
-              "# Rule selection" // new_line('a') // &
-              'select = ["F", "W"]  # Enable F and W rules' // new_line('a') // &
-              'ignore = ["F001"]    # Disable specific rules' // new_line('a') // &
-              'extend-select = ["C"] # Add more rules' // new_line('a') // &
-              new_line('a') // &
-              "# Per-file ignores" // new_line('a') // &
-              "[tool.fluff.per-file-ignores]" // new_line('a') // &
-              '"test/*.f90" = ["F001", "W002"]' // new_line('a') // &
-              '"legacy/*.f90" = ["F", "W"]' // new_line('a') // &
-              "```" // new_line('a') // &
-              new_line('a') // &
-              "## Rule Categories" // new_line('a') // &
-              "- F: Style and formatting" // new_line('a') // &
-              "- W: Warnings" // new_line('a') // &
-              "- C: Correctness" // new_line('a') // &
-              "- P: Performance" // new_line('a') // &
-              "- S: Security" // new_line('a') // &
-              "- ALL: All rules" // new_line('a')
-        
+
+        doc = "# fluff Configuration Schema"//new_line('a')// &
+              new_line('a')// &
+"Configuration can be specified in `fluff.toml` or `pyproject.toml`:"//new_line('a')// &
+              new_line('a')// &
+              "```toml"//new_line('a')// &
+              "[tool.fluff]"//new_line('a')// &
+              "# Enable automatic fixing of violations"//new_line('a')// &
+              "fix = false"//new_line('a')// &
+              new_line('a')// &
+              "# Show suggested fixes"//new_line('a')// &
+              "show-fixes = false"//new_line('a')// &
+              new_line('a')// &
+              "# Maximum line length (40-200)"//new_line('a')// &
+              "line-length = 88"//new_line('a')// &
+              new_line('a')// &
+              "# Tab width for visual column calculation (1-16)"//new_line('a')// &
+              "tab-width = 4"//new_line('a')// &
+              new_line('a')// &
+              "# Target Fortran version: 2008, 2018, 2023"//new_line('a')// &
+              'target-version = "2018"'//new_line('a')// &
+              new_line('a')// &
+              "# Output format: text, json, sarif"//new_line('a')// &
+              'output-format = "text"'//new_line('a')// &
+              new_line('a')// &
+              "# Rule selection"//new_line('a')// &
+              'select = ["F", "W"]  # Enable F and W rules'//new_line('a')// &
+              'ignore = ["F001"]    # Disable specific rules'//new_line('a')// &
+              'extend-select = ["C"] # Add more rules'//new_line('a')// &
+              new_line('a')// &
+              "# Per-file ignores"//new_line('a')// &
+              "[tool.fluff.per-file-ignores]"//new_line('a')// &
+              '"test/*.f90" = ["F001", "W002"]'//new_line('a')// &
+              '"legacy/*.f90" = ["F", "W"]'//new_line('a')// &
+              "```"//new_line('a')// &
+              new_line('a')// &
+              "## Rule Categories"//new_line('a')// &
+              "- F: Style and formatting"//new_line('a')// &
+              "- W: Warnings"//new_line('a')// &
+              "- C: Correctness"//new_line('a')// &
+              "- P: Performance"//new_line('a')// &
+              "- S: Security"//new_line('a')// &
+              "- ALL: All rules"//new_line('a')
+
     end function get_config_schema_doc
-    
+
 end module fluff_config

--- a/src/fluff_linter/fluff_linter.f90
+++ b/src/fluff_linter/fluff_linter.f90
@@ -135,7 +135,8 @@ contains
         ! containing fortfront arena and semantic context with pointer components
         call ast_ctx%from_source(source_code, error_msg)
 
-        call set_current_file_context(filename, this%config%line_length)
+        call set_current_file_context(filename, this%config%line_length, &
+                                      this%config%tab_width)
 
         if (allocated(error_msg) .and. len(error_msg) > 0) then
             print *, "ERROR: fortfront AST parsing failed in linter!"

--- a/src/fluff_rules/fluff_rule_file_context.f90
+++ b/src/fluff_rules/fluff_rule_file_context.f90
@@ -4,16 +4,19 @@ module fluff_rule_file_context
 
     public :: current_filename
     public :: current_line_length
+    public :: current_tab_width
     public :: set_current_file_context
 
     character(len=:), allocatable :: current_filename
     integer :: current_line_length = 88
+    integer :: current_tab_width = 4
 
 contains
 
-    subroutine set_current_file_context(filename, line_length)
+    subroutine set_current_file_context(filename, line_length, tab_width)
         character(len=*), intent(in) :: filename
         integer, intent(in), optional :: line_length
+        integer, intent(in), optional :: tab_width
 
         current_filename = filename
         if (present(line_length)) then
@@ -24,6 +27,15 @@ contains
             end if
         else
             current_line_length = 88
+        end if
+        if (present(tab_width)) then
+            if (tab_width > 0) then
+                current_tab_width = tab_width
+            else
+                current_tab_width = 4
+            end if
+        else
+            current_tab_width = 4
         end if
     end subroutine set_current_file_context
 

--- a/src/fluff_rules/style/fluff_rule_f003.f90
+++ b/src/fluff_rules/style/fluff_rule_f003.f90
@@ -2,7 +2,8 @@ module fluff_rule_f003
     use fluff_ast, only: fluff_ast_context_t
     use fluff_core, only: source_range_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
-    use fluff_rule_file_context, only: current_filename, current_line_length
+    use fluff_rule_file_context, only: current_filename, current_line_length, &
+                                       current_tab_width
     use fluff_rule_diagnostic_utils, only: push_diagnostic
     use fluff_text_helpers, only: is_comment_only_line, int_to_str
     use fluff_visual_columns, only: visual_columns
@@ -24,6 +25,7 @@ contains
         integer :: line_num
         integer :: max_length
         integer :: line_length
+        integer :: tab_width
         logical :: found
         character(len=:), allocatable :: line_text
 
@@ -35,13 +37,16 @@ contains
         max_length = current_line_length
         if (max_length <= 0) max_length = 88
 
+        tab_width = current_tab_width
+        if (tab_width <= 0) tab_width = 4
+
         violation_count = 0
         line_num = 1
         do
             call ctx%get_source_line(line_num, line_text, found)
             if (.not. found) exit
 
-            line_length = visual_columns(line_text)
+            line_length = visual_columns(line_text, tab_width)
             if (line_length > max_length) then
                 if (.not. is_comment_only_line(line_text)) then
                     call push_diagnostic(buffer, violation_count, &


### PR DESCRIPTION
## Summary
- Add `tab_width` configuration option (default 4, range 1-16) to control visual column calculation in F003 line length diagnostics
- Allows users to match fluff behavior with their editor tab settings
- Passes tab_width through the full configuration pipeline to the F003 rule

## Changes
- `src/fluff_config/fluff_config.f90`: Add `tab_width` field to `fluff_config_t` type with validation, namelist parsing, and merge support
- `src/fluff_rules/fluff_rule_file_context.f90`: Add `current_tab_width` module variable and update `set_current_file_context` to accept tab_width
- `src/fluff_rules/style/fluff_rule_f003.f90`: Pass configured tab_width to `visual_columns()` function
- `src/fluff_linter/fluff_linter.f90`: Pass `config%tab_width` to `set_current_file_context`
- `fluff.toml`: Add `tab_width = 4` configuration option
- `README.md`: Document new configuration option

## Test plan
- [x] All existing tests pass (including F003 tab test)
- [x] Visual columns module already supports tab_width parameter
- [x] Config validation rejects invalid tab_width values

Generated with [Claude Code](https://claude.com/claude-code)