### PR TITLE
fix: extend F014 unnecessary parentheses detection (fixes #150)

### DIFF
--- a/src/fluff_rules/style/fluff_rule_f014.f90
+++ b/src/fluff_rules/style/fluff_rule_f014.f90
@@ -23,7 +23,6 @@ contains
         logical :: found
         type(token_t), allocatable :: tokens(:)
         integer, allocatable :: close_for_open(:)
-        integer, allocatable :: open_for_close(:)
         type(diagnostic_t), allocatable :: tmp(:)
         integer :: violation_count
 
@@ -38,17 +37,16 @@ contains
         allocate (tmp(0))
         violation_count = 0
 
-        call build_paren_pairs(tokens, close_for_open, open_for_close)
+        call build_paren_pairs(tokens, close_for_open)
         call find_unnecessary_parens(tokens, close_for_open, tmp, violation_count)
 
         allocate (violations(violation_count))
         if (violation_count > 0) violations = tmp(1:violation_count)
     end subroutine check_f014_unnecessary_parentheses
 
-    subroutine build_paren_pairs(tokens, close_for_open, open_for_close)
+    subroutine build_paren_pairs(tokens, close_for_open)
         type(token_t), allocatable, intent(in) :: tokens(:)
         integer, allocatable, intent(out) :: close_for_open(:)
-        integer, allocatable, intent(out) :: open_for_close(:)
 
         integer, allocatable :: stack(:)
         integer :: top
@@ -56,22 +54,17 @@ contains
         integer :: open_idx
 
         if (allocated(close_for_open)) deallocate (close_for_open)
-        if (allocated(open_for_close)) deallocate (open_for_close)
         if (.not. allocated(tokens)) then
             allocate (close_for_open(0))
-            allocate (open_for_close(0))
             return
         end if
         if (size(tokens) <= 0) then
             allocate (close_for_open(0))
-            allocate (open_for_close(0))
             return
         end if
 
         allocate (close_for_open(size(tokens)))
-        allocate (open_for_close(size(tokens)))
         close_for_open = 0
-        open_for_close = 0
 
         allocate (stack(size(tokens)))
         top = 0
@@ -87,7 +80,6 @@ contains
                 open_idx = stack(top)
                 top = top - 1
                 close_for_open(open_idx) = i
-                open_for_close(i) = open_idx
             end if
         end do
         deallocate (stack)
@@ -101,6 +93,7 @@ contains
 
         integer :: open_idx
         integer :: close_idx
+        logical :: is_single_line
 
         if (.not. allocated(tokens)) return
         if (size(tokens) <= 0) return
@@ -108,30 +101,47 @@ contains
         do open_idx = 1, size(tokens)
             close_idx = close_for_open(open_idx)
             if (close_idx <= 0) cycle
-            if (tokens(open_idx)%line /= tokens(close_idx)%line) cycle
             if (open_idx > 1) then
                 if (tokens(open_idx - 1)%kind == TK_IDENTIFIER) cycle
                 if (tokens(open_idx - 1)%kind == TK_KEYWORD) cycle
             end if
+
+            is_single_line = (tokens(open_idx)%line == tokens(close_idx)%line)
+
             if (is_double_parens(tokens, close_for_open, open_idx, close_idx)) then
-                call push_diagnostic(tmp, violation_count, create_diagnostic( &
-                                     code="F014", &
-                                  message="Unnecessary parentheses around expression", &
-                                     file_path=current_filename, &
-                                     location=paren_location(tokens(open_idx), &
-                                                             tokens(close_idx)), &
-                                     severity=SEVERITY_INFO))
-            else if (is_simple_parens(tokens, open_idx, close_idx)) then
-                call push_diagnostic(tmp, violation_count, create_diagnostic( &
-                                     code="F014", &
-                           message="Unnecessary parentheses around simple expression", &
-                                     file_path=current_filename, &
-                                     location=paren_location(tokens(open_idx), &
-                                                             tokens(close_idx)), &
-                                     severity=SEVERITY_INFO))
+                call report_unnecessary_parens(tmp, violation_count, &
+                                               "Unnecessary parentheses", &
+                                               tokens(open_idx), tokens(close_idx))
+            else if (is_single_line) then
+                if (is_simple_parens(tokens, open_idx, close_idx)) then
+                    call report_unnecessary_parens(tmp, violation_count, &
+                                                   "Unnecessary simple parentheses", &
+                                                   tokens(open_idx), tokens(close_idx))
+                else if (is_redundant_relational_parens(tokens, close_for_open, &
+                                                        open_idx, close_idx)) then
+                    call report_unnecessary_parens(tmp, violation_count, &
+                                                   "Unnecessary relational parens", &
+                                                   tokens(open_idx), tokens(close_idx))
+                end if
             end if
         end do
     end subroutine find_unnecessary_parens
+
+    subroutine report_unnecessary_parens(tmp, violation_count, msg, open_tok, &
+                                         close_tok)
+        type(diagnostic_t), allocatable, intent(inout) :: tmp(:)
+        integer, intent(inout) :: violation_count
+        character(len=*), intent(in) :: msg
+        type(token_t), intent(in) :: open_tok
+        type(token_t), intent(in) :: close_tok
+
+        call push_diagnostic(tmp, violation_count, create_diagnostic( &
+                             code="F014", &
+                             message=msg, &
+                             file_path=current_filename, &
+                             location=paren_location(open_tok, close_tok), &
+                             severity=SEVERITY_INFO))
+    end subroutine report_unnecessary_parens
 
     pure logical function is_simple_parens(tokens, open_idx, close_idx) result(ok)
         type(token_t), intent(in) :: tokens(:)
@@ -175,6 +185,138 @@ contains
 
         ok = .true.
     end function is_double_parens
+
+    pure logical function is_redundant_relational_parens(tokens, close_for_open, &
+                                                         open_idx, &
+                                                         close_idx) result(ok)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: close_for_open(:)
+        integer, intent(in) :: open_idx
+        integer, intent(in) :: close_idx
+
+        integer :: inner_open
+        integer :: inner_close
+        logical :: has_relational
+
+        ok = .false.
+
+        if (open_idx + 1 >= close_idx) return
+        if (tokens(open_idx + 1)%kind /= TK_OPERATOR) return
+        if (.not. allocated(tokens(open_idx + 1)%text)) return
+        if (tokens(open_idx + 1)%text /= "(") return
+
+        inner_open = open_idx + 1
+        inner_close = close_for_open(inner_open)
+        if (inner_close <= 0) return
+        if (inner_close /= close_idx - 1) return
+
+        has_relational = contains_only_relational_logical(tokens, inner_open, &
+                                                          inner_close, &
+                                                          close_for_open)
+        if (.not. has_relational) return
+
+        ok = .true.
+    end function is_redundant_relational_parens
+
+    pure logical function contains_only_relational_logical(tokens, open_idx, &
+                                                           close_idx, &
+                                                           close_for_open) result(ok)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: open_idx
+        integer, intent(in) :: close_idx
+        integer, intent(in) :: close_for_open(:)
+
+        integer :: i
+        integer :: nested_close
+        logical :: found_relational_or_logical
+
+        ok = .false.
+        found_relational_or_logical = .false.
+
+        i = open_idx + 1
+        do while (i < close_idx)
+            if (tokens(i)%kind == TK_OPERATOR) then
+                if (allocated(tokens(i)%text)) then
+                    if (tokens(i)%text == "(") then
+                        nested_close = close_for_open(i)
+                        if (nested_close > 0) then
+                            i = nested_close
+                        end if
+                    else if (is_relational_op(tokens(i)%text) .or. &
+                             is_logical_op(tokens(i)%text)) then
+                        found_relational_or_logical = .true.
+                    else if (is_arithmetic_op(tokens(i)%text)) then
+                        return
+                    end if
+                end if
+            end if
+            i = i + 1
+        end do
+
+        ok = found_relational_or_logical
+    end function contains_only_relational_logical
+
+    pure logical function is_relational_op(text) result(ok)
+        character(len=*), intent(in) :: text
+
+        character(len=16) :: lower_text
+        integer :: i
+        character :: c
+
+        ok = .false.
+
+        lower_text = ""
+        do i = 1, min(len_trim(text), 16)
+            c = text(i:i)
+            if (c >= 'A' .and. c <= 'Z') then
+                lower_text(i:i) = char(ichar(c) + 32)
+            else
+                lower_text(i:i) = c
+            end if
+        end do
+
+        select case (trim(lower_text))
+        case (".eq.", ".ne.", ".lt.", ".le.", ".gt.", ".ge.", &
+              "==", "/=", "<", ">", "<=", ">=")
+            ok = .true.
+        end select
+    end function is_relational_op
+
+    pure logical function is_logical_op(text) result(ok)
+        character(len=*), intent(in) :: text
+
+        character(len=16) :: lower_text
+        integer :: i
+        character :: c
+
+        ok = .false.
+
+        lower_text = ""
+        do i = 1, min(len_trim(text), 16)
+            c = text(i:i)
+            if (c >= 'A' .and. c <= 'Z') then
+                lower_text(i:i) = char(ichar(c) + 32)
+            else
+                lower_text(i:i) = c
+            end if
+        end do
+
+        select case (trim(lower_text))
+        case (".and.", ".or.", ".not.", ".eqv.", ".neqv.")
+            ok = .true.
+        end select
+    end function is_logical_op
+
+    pure logical function is_arithmetic_op(text) result(ok)
+        character(len=*), intent(in) :: text
+
+        ok = .false.
+
+        select case (trim(text))
+        case ("+", "-", "*", "/", "**")
+            ok = .true.
+        end select
+    end function is_arithmetic_op
 
     pure function paren_location(open_tok, close_tok) result(location)
         type(token_t), intent(in) :: open_tok


### PR DESCRIPTION
## Summary
- Extend F014 rule to detect redundant parentheses around relational/logical subexpressions
- Remove single-line restriction for double parentheses detection (now works on multi-line)
- Add helper functions to classify relational, logical, and arithmetic operators
- Clean up unused open_for_close array (Boy Scout Principle)

## Test plan
- [x] fpm build passes
- [x] fpm test passes (100%)
- [x] F014-specific tests pass
- [x] fprettify formatting applied

Generated with [Claude Code](https://claude.com/claude-code)