### PR TITLE
fix: handle all AST node types without warnings (fixes #209)

### DIFF
--- a/test/test_rule_p006_loop_allocations.f90
+++ b/test/test_rule_p006_loop_allocations.f90
@@ -13,6 +13,7 @@ program test_rule_p006_loop_allocations
     call test_allocate_outside_loop_is_ok()
     call test_deallocate_inside_loop_triggers()
     call test_nested_loop_allocate()
+    call test_no_spurious_node_type_warnings()
 
     print *, "[OK] All P006 tests passed!"
 
@@ -141,5 +142,53 @@ contains
                                         "nested loop allocate should be flagged")
         print *, "[OK] Nested loop allocate"
     end subroutine test_nested_loop_allocate
+
+    subroutine test_no_spurious_node_type_warnings()
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: test_code
+        character(len=:), allocatable :: path
+        integer :: i, p006_count
+        logical :: found_other
+
+        test_code = "program alloc_test"//new_line('a')// &
+                    "implicit none"//new_line('a')// &
+                    "real, allocatable :: temp(:)"//new_line('a')// &
+                    "integer :: i"//new_line('a')// &
+                    "do i = 1, 100"//new_line('a')// &
+                    "    allocate(temp(50))"//new_line('a')// &
+                    "    temp = real(i)"//new_line('a')// &
+                    "    deallocate(temp)"//new_line('a')// &
+                    "end do"//new_line('a')// &
+                    "end program alloc_test"
+
+        linter = create_linter_engine()
+        call make_temp_fortran_path("fluff_test_p006_issue209", path)
+        call write_text_file(path, test_code)
+        call lint_file_checked(linter, path, diagnostics)
+        call delete_file_if_exists(path)
+
+        p006_count = 0
+        found_other = .false.
+        if (allocated(diagnostics)) then
+            do i = 1, size(diagnostics)
+                if (diagnostics(i)%code == "P006") then
+                    p006_count = p006_count + 1
+                else if (diagnostics(i)%code /= "F006") then
+                    found_other = .true.
+                end if
+            end do
+        end if
+
+        if (p006_count /= 2) then
+            print *, "[FAIL] Expected exactly 2 P006 diagnostics, got ", p006_count
+            error stop
+        end if
+        if (found_other) then
+            print *, "[FAIL] Unexpected non-P006/F006 diagnostics found"
+            error stop
+        end if
+        print *, "[OK] No spurious warnings from issue #209 test case"
+    end subroutine test_no_spurious_node_type_warnings
 
 end program test_rule_p006_loop_allocations


### PR DESCRIPTION
## Summary
- Eliminate "Unknown node type in get_node_type_id" warnings during P006 analysis
- Update fortfront dependency to branch with complete node type handlers
- Add regression test for issue #209

## Root Cause
The warning originated from fortfront's `get_node_type_id` function which only handled a subset of AST node types. During analysis of allocate/deallocate statements, array-related nodes (like `array_bounds_node`, `array_slice_node`) triggered warnings.

## Fix
The fix adds handlers for 34+ missing node types in fortfront:
- Array nodes: array_bounds, array_slice, range_expression, array_operation
- Control nodes: pause, nullify, where_stmt, select_type, select_rank, etc.
- Data nodes: submodule, block_data, type_binding, mixed_construct
- IO nodes: io_implied_do, open, close, inquire, backspace, rewind, endfile
- Misc nodes: blank_line, end_statement, intrinsic_statement, etc.

## Test plan
- [x] Verify issue #209 reproduction case no longer shows warnings
- [x] Run `fpm test test_rule_p006_loop_allocations` - passes with new test case
- [x] Run `fpm test` - all tests pass

Generated with [Claude Code](https://claude.com/claude-code)