### PR TITLE
fix: LSP server request/response handling (fixes #208)

### DIFF
--- a/test/test_lsp_dispatcher.f90
+++ b/test/test_lsp_dispatcher.f90
@@ -72,6 +72,12 @@ contains
             return
         end if
 
+        call json_has_member(result_json, "serverInfo", found, ok)
+        if (.not. ok .or. .not. found) then
+            print *, "[FAIL] Initialize - missing serverInfo"
+            return
+        end if
+
         if (.not. dispatcher%server%is_initialized) then
             print *, "[FAIL] Initialize - server not marked initialized"
             return


### PR DESCRIPTION
## Summary
- Fixed LSP server not responding to initialize requests (issue #208)
- CLI handlers now properly call `server%initialize()` before generating response
- CLI handlers now use `get_initialize_result()` to include serverInfo in response
- Fixed I/O framing to use stream access for correct byte-level reading from pipes
- Added test verification for serverInfo presence in initialize response

## Test plan
- [x] Run `fpm test` - all LSP tests pass (100%)
- [x] Verify server responds to initialize request:
  ```
  printf 'Content-Length: 133\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}' | fluff server
  ```
- [x] Response includes capabilities and serverInfo

Generated with Claude Opus 4.5