### PR TITLE
fix: F001 skips empty/comment-only files (fixes #227)

### DIFF
--- a/test/test_rule_interface.f90
+++ b/test/test_rule_interface.f90
@@ -33,8 +33,9 @@ contains
         integer :: node_index
         character(len=:), allocatable :: error_msg
 
-        ! Create test AST context
+        ! Create test AST context (with declaration to trigger F001)
         call ast_ctx%from_source("program test"//new_line('a')// &
+                                 "    integer :: x"//new_line('a')// &
                                  "end program test", error_msg)
 
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then


### PR DESCRIPTION
## Summary
- Empty files and comment-only files no longer incorrectly flagged for F001
- Rule now checks if the scope contains variable declarations before requiring implicit none
- Add `scope_has_declarations()` helper function

## Verification

### Test fails on main
```
$ git checkout main
$ touch /tmp/empty.f90
$ cat > /tmp/comments.f90 << 'TESTEOF'
! Just a comment
! Another comment
TESTEOF
$ fpm run -- check /tmp/empty.f90 /tmp/comments.f90 2>&1
/tmp/empty.f90   :1:1 [WARNING] Missing implicit none statement (F001)
/tmp/comments.f90:1:1 [WARNING] Missing implicit none statement (F001)
```

### Test passes after fix
```
$ git checkout fix-227-f001-empty-files
$ fpm run -- check /tmp/empty.f90 /tmp/comments.f90 2>&1
Project is up to date
```

No F001 warnings for empty/comment-only files. Files with actual declarations still flagged:
```
$ cat > /tmp/needs_implicit.f90 << 'TESTEOF'
program needs_implicit
    integer :: x
    x = 5
end program needs_implicit
TESTEOF
$ fpm run -- check /tmp/needs_implicit.f90 2>&1
/tmp/needs_implicit.f90:1:1 [WARNING] Missing implicit none statement (F001)
```