### PR TITLE
fix: add missing filename prefix to diagnostics (fixes #223)

### DIFF
--- a/src/fluff_rules/fluff_rule_f009.f90
+++ b/src/fluff_rules/fluff_rule_f009.f90
@@ -3,6 +3,7 @@ module fluff_rule_f009
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_core, only: source_range_t
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: assignment_node, call_or_subscript_node, declaration_node, &
                          identifier_node
     implicit none
@@ -152,7 +153,7 @@ contains
                                         code="F009", &
                                         message= &
                                         "Do not assign to intent(in) dummy argument", &
-                                        file_path="", &
+                                        file_path=current_filename, &
                                         location=location, &
                                         severity=SEVERITY_WARNING &
                                         ))
@@ -175,7 +176,7 @@ contains
                                     code="F009", &
                                     message= &
                                     "intent(out) dummy argument is never assigned", &
-                                    file_path="", &
+                                    file_path=current_filename, &
                                     location=intents(i)%decl_location, &
                                     severity=SEVERITY_WARNING &
                                     ))

--- a/src/fluff_rules/perf/fluff_rule_p001.f90
+++ b/src/fluff_rules/perf/fluff_rule_p001.f90
@@ -2,6 +2,7 @@ module fluff_rule_p001
     use fluff_ast, only: fluff_ast_context_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: assignment_node, call_or_subscript_node, do_loop_node, &
                          identifier_node, binary_op_node, if_node, &
                          select_case_node, &
@@ -225,7 +226,7 @@ contains
                                          message= &
                                          "Leftmost array index varies in an outer " &
                                          //"loop; consider swapping loop order", &
-                                         file_path="", &
+                                         file_path=current_filename, &
                                          location=ctx%get_node_location(node_index), &
                                          severity=SEVERITY_WARNING))
                 end if

--- a/src/fluff_rules/perf/fluff_rule_p002.f90
+++ b/src/fluff_rules/perf/fluff_rule_p002.f90
@@ -2,6 +2,7 @@ module fluff_rule_p002
     use fluff_ast, only: fluff_ast_context_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: assignment_node, binary_op_node, call_or_subscript_node, &
                          do_loop_node, identifier_node
     implicit none
@@ -63,7 +64,7 @@ contains
                                                 create_diagnostic( &
                                                 code="P002", &
                                              message="Consider swapping nested loops", &
-                                                file_path="", &
+                                                file_path=current_filename, &
                                                 location=ctx%get_node_location( &
                                                 inner_index), &
                                                 severity=SEVERITY_INFO &

--- a/src/fluff_rules/perf/fluff_rule_p003.f90
+++ b/src/fluff_rules/perf/fluff_rule_p003.f90
@@ -2,6 +2,7 @@ module fluff_rule_p003
     use fluff_ast, only: fluff_ast_context_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: assignment_node, binary_op_node, declaration_node, &
                          identifier_node, literal_node
     implicit none
@@ -54,7 +55,7 @@ contains
                                         code="P003", &
                                         message="Whole-array expression may "// &
                                         "create temporaries", &
-                                        file_path="", &
+                                        file_path=current_filename, &
                                         location=ctx%get_node_location(i), &
                                         severity=SEVERITY_INFO &
                                         ))

--- a/src/fluff_rules/perf/fluff_rule_p004.f90
+++ b/src/fluff_rules/perf/fluff_rule_p004.f90
@@ -2,6 +2,7 @@ module fluff_rule_p004
     use fluff_ast, only: fluff_ast_context_t, NODE_FUNCTION_DEF, NODE_SUBROUTINE_DEF
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: allocate_statement_node, call_or_subscript_node, &
                          declaration_node, error_stop_node, function_def_node, &
                          identifier_node, print_statement_node, read_statement_node, &
@@ -34,7 +35,7 @@ contains
                     call push_diagnostic(tmp, violation_count, create_diagnostic( &
                                          code="P004", &
                             message="Consider adding pure attribute for optimization", &
-                                         file_path="", &
+                                         file_path=current_filename, &
                                          location=ctx%get_node_location(i), &
                                          severity=SEVERITY_INFO))
                 end if

--- a/src/fluff_rules/perf/fluff_rule_p005.f90
+++ b/src/fluff_rules/perf/fluff_rule_p005.f90
@@ -2,6 +2,7 @@ module fluff_rule_p005
     use fluff_ast, only: fluff_ast_context_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: assignment_node, binary_op_node, call_or_subscript_node, &
                          declaration_node, do_loop_node, identifier_node, &
                          symbol_info_t, TCHAR
@@ -48,7 +49,7 @@ contains
                         call push_diagnostic(tmp, violation_count, create_diagnostic( &
                                              code="P005", &
                              message="String concatenation in loops can be expensive", &
-                                             file_path="", &
+                                             file_path=current_filename, &
                                           location=ctx%get_node_location(concat_node), &
                                              severity=SEVERITY_INFO))
                         exit

--- a/src/fluff_rules/perf/fluff_rule_p006.f90
+++ b/src/fluff_rules/perf/fluff_rule_p006.f90
@@ -3,6 +3,7 @@ module fluff_rule_p006
                          NODE_DEALLOCATE_STATEMENT
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_WARNING
     use fluff_rule_diagnostic_utils, only: push_diagnostic
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: allocate_statement_node, assignment_node, binary_op_node, &
                          call_or_subscript_node, deallocate_statement_node, do_loop_node
     implicit none
@@ -61,7 +62,7 @@ contains
                     call push_diagnostic(tmp, violation_count, create_diagnostic( &
                                          code="P006", &
                                          message="Avoid allocate inside loops", &
-                                         file_path="", &
+                                         file_path=current_filename, &
                                          location=ctx%get_node_location(alloc_node), &
                                          severity=SEVERITY_WARNING))
                 end if
@@ -69,7 +70,7 @@ contains
                     call push_diagnostic(tmp, violation_count, create_diagnostic( &
                                          code="P006", &
                                          message="Avoid deallocate inside loops", &
-                                         file_path="", &
+                                         file_path=current_filename, &
                                          location=ctx%get_node_location(dealloc_node), &
                                          severity=SEVERITY_WARNING))
                 end if

--- a/src/fluff_rules/perf/fluff_rule_p007.f90
+++ b/src/fluff_rules/perf/fluff_rule_p007.f90
@@ -2,6 +2,7 @@ module fluff_rule_p007
     use fluff_ast, only: fluff_ast_context_t
     use fluff_diagnostics, only: diagnostic_t, create_diagnostic, SEVERITY_INFO
     use fluff_rule_diagnostic_utils, only: push_diagnostic, to_lower_ascii
+    use fluff_rule_file_context, only: current_filename
     use fortfront, only: binary_op_node, call_or_subscript_node, declaration_node, &
                          identifier_node, literal_node, symbol_info_t, TREAL
     implicit none
@@ -54,7 +55,7 @@ contains
                                          code="P007", &
                                          message="Mixed precision arithmetic can "// &
                                          "hurt performance", &
-                                         file_path="", &
+                                         file_path=current_filename, &
                                          location=ctx%get_node_location(i), &
                                          severity=SEVERITY_INFO &
                                          ))


### PR DESCRIPTION
## Summary
- All rules now properly use `current_filename` from `fluff_rule_file_context` module
- Rules fixed: F009, P001, P002, P003, P004, P005, P006, P007
- Diagnostics now show full path like `path/to/file.f90:1:1` instead of `:1:1`

## Verification

### Test fails on main
```
$ git checkout main
$ cat > /tmp/test_f009.f90 << 'TESTEOF'
subroutine test_f009(x, y)
    implicit none
    integer, intent(out) :: x
    integer, intent(in) :: y
end subroutine test_f009
TESTEOF
$ fpm run -- check /tmp/test_f009.f90 2>&1
:1:1 [WARNING] intent(out) dummy argument is never assigned (F009)
:1:1 [INFO] Consider adding pure attribute for optimization (P004)
```

### Test passes after fix
```
$ git checkout fix-223-diagnostic-filenames
$ fpm run -- check /tmp/test_f009.f90 2>&1
/tmp/test_f009.f90:1:1 [WARNING] intent(out) dummy argument is never assigned (F009)
/tmp/test_f009.f90:1:1 [INFO] Consider adding pure attribute for optimization (P004)
```

All diagnostics now include the filename prefix.