### PR TITLE
fix: F005 detects file-level mixed indentation (fixes #224)

### DIFF
--- a/test/test_rule_f005_mixed_tabs_spaces.f90
+++ b/test/test_rule_f005_mixed_tabs_spaces.f90
@@ -49,7 +49,10 @@ contains
 
         call assert_error_empty(error_msg)
         call count_code(diagnostics, "F005", f005_count)
-        call assert_equal_int(f005_count, 1, "Expected 1 F005 violation")
+        ! Line 3: tab-only when file uses spaces -> 1 violation
+        ! Line 4: mixed tabs+spaces in same line -> 1 violation
+        call assert_equal_int(f005_count, 2, "Expected 2 F005 violations")
+        call assert_f005_location(diagnostics, 3, 1, 1)
         call assert_f005_location(diagnostics, 4, 1, 3)
 
         ! Clean up
@@ -171,7 +174,11 @@ contains
         open (unit=99, file=path, status="old")
         close (99, status="delete")
 
-        call assert_equal_int(f005_count, 2, "Expected 2 F005 violations")
+        ! Line 3: tab-only when file uses spaces -> 1 violation
+        ! Line 4: mixed tabs+spaces in same line -> 1 violation
+        ! Line 5: mixed tabs+spaces in same line -> 1 violation
+        call assert_equal_int(f005_count, 3, "Expected 3 F005 violations")
+        call assert_f005_location(diagnostics, 3, 1, 1)
         call assert_f005_location(diagnostics, 4, 1, 3)
         call assert_f005_location(diagnostics, 5, 1, 3)
 


### PR DESCRIPTION
## Summary
- Enhance F005 rule to detect inconsistent indentation style across lines
- Track file indentation style (tabs or spaces) from first indented line
- Report violations when a line uses different indentation style than the file norm

## Changes
- Add INDENT_NONE, INDENT_SPACES, INDENT_TABS constants
- Track file_indent_style across the file
- Report violation when indentation style differs from established norm
- Update tests to expect new violations

## Verification

### Before (on main)
```bash
$ cat test_f005.f90  # File with tabs on some lines, spaces on others
program test_f005
    implicit none      # tab
    integer :: x       # spaces
    x = 5              # tab
end program test_f005

$ fluff check test_f005.f90
# (no output - bug)
```

### After (on branch)
```
$ fpm run -- check /tmp/test_f005.f90
/tmp/test_f005.f90:3:1 [WARNING] Mixed tabs and spaces

$ fpm test test_rule_f005_mixed_tabs_spaces
 [OK] Mixed tabs and spaces
 [OK] Only spaces
 [OK] Only tabs
 [OK] Multiple mixed indentations
 [OK] All F005 tests passed!
```

## Test plan
- [x] Run fpm test test_rule_f005_mixed_tabs_spaces - all tests pass
- [x] Run fpm test - full test suite passes
- [x] Test with mixed tab/space file - F005 now detected