### PR TITLE
Add file key to diagnostic JSON output

### DIFF
--- a/src/fluff_diagnostics/fluff_diagnostics.f90
+++ b/src/fluff_diagnostics/fluff_diagnostics.f90
@@ -187,6 +187,7 @@ contains
     function diagnostic_to_json(this) result(json)
         class(diagnostic_t), intent(in) :: this
         character(len=:), allocatable :: json
+        character(len=:), allocatable :: file_str
         character(len=20) :: line_str, col_str, end_line_str, end_col_str
 
         ! Convert integers to strings to avoid format issues
@@ -195,11 +196,19 @@ contains
         write(end_line_str, '(I0)') this%location%end%line
         write(end_col_str, '(I0)') this%location%end%column
 
+        ! Handle file_path - empty string if unallocated
+        if (allocated(this%file_path)) then
+            file_str = escape_json_value(this%file_path)
+        else
+            file_str = ""
+        end if
+
         json = '{' // new_line('a') // &
             '  "code": "' // this%code // '",' // new_line('a') // &
             '  "message": "' // this%message // '",' // new_line('a') // &
             '  "severity": "' // severity_to_string(this%severity) // '",' // new_line('a') // &
             '  "category": "' // this%category // '",' // new_line('a') // &
+            '  "file": "' // file_str // '",' // new_line('a') // &
             '  "location": {' // new_line('a') // &
             '    "start": {"line": ' // trim(line_str) // ', "column": ' // trim(col_str) // '},' // new_line('a') // &
             '    "end": {"line": ' // trim(end_line_str) // ', "column": ' // trim(end_col_str) // '}' // new_line('a') // &
@@ -894,5 +903,38 @@ contains
             end if
         end if
     end function should_swap_diagnostics
+
+    ! Escape special characters for JSON without adding quotes
+    function escape_json_value(value) result(escaped)
+        character(len=*), intent(in) :: value
+        character(len=:), allocatable :: escaped
+
+        character(len=len(value)*2) :: buffer
+        integer :: i, j
+
+        j = 1
+        do i = 1, len_trim(value)
+            select case (value(i:i))
+            case ('"')
+                buffer(j:j+1) = '\"'
+                j = j + 2
+            case ('\')
+                buffer(j:j+1) = '\\'
+                j = j + 2
+            case (char(10))
+                buffer(j:j+1) = '\n'
+                j = j + 2
+            case (char(9))
+                buffer(j:j+1) = '\t'
+                j = j + 2
+            case default
+                buffer(j:j) = value(i:i)
+                j = j + 1
+            end select
+        end do
+
+        escaped = buffer(1:j-1)
+
+    end function escape_json_value
 
 end module fluff_diagnostics

--- a/test/test_json_filepath.f90
+++ b/test/test_json_filepath.f90
@@ -1,0 +1,83 @@
+program test_json_filepath
+    use fluff_core
+    use fluff_diagnostics
+    implicit none
+
+    type(diagnostic_t) :: diag
+    type(source_range_t) :: loc
+    character(len=:), allocatable :: json
+    integer :: file_idx, path_idx
+
+    ! Setup location
+    loc%start%line = 42
+    loc%start%column = 10
+    loc%end%line = 42
+    loc%end%column = 20
+
+    ! Create diagnostic with file_path
+    diag = create_diagnostic( &
+        code = "F001", &
+        message = "Test message", &
+        severity = SEVERITY_WARNING, &
+        location = loc, &
+        file_path = "src/test/file.f90" &
+        )
+
+    ! Convert to JSON
+    json = diag%to_json()
+
+    ! Check that "file" key is present
+    file_idx = index(json, '"file"')
+    if (file_idx == 0) then
+        print '(a)', 'FAIL: "file" key not found in JSON output'
+        stop 1
+    end if
+
+    ! Check that the file path is in the output
+    path_idx = index(json, 'src/test/file.f90')
+    if (path_idx == 0) then
+        print '(a)', 'FAIL: file path not found in JSON output'
+        stop 1
+    end if
+
+    ! Check that "file" appears before the path value in the correct format
+    if (file_idx > path_idx) then
+        print '(a)', 'FAIL: "file" key not properly positioned before path value'
+        stop 1
+    end if
+
+    ! Verify file key is after category and before location
+    if (index(json, '"category"') >= file_idx) then
+        print '(a)', 'FAIL: "file" key not after "category"'
+        stop 1
+    end if
+
+    if (index(json, '"location"') <= file_idx) then
+        print '(a)', 'FAIL: "file" key not before "location"'
+        stop 1
+    end if
+
+    ! Test with empty file_path (unallocated)
+    diag%file_path = ""
+    json = diag%to_json()
+
+    file_idx = index(json, '"file": ""')
+    if (file_idx == 0) then
+        print '(a)', 'FAIL: empty file path not handled correctly'
+        stop 1
+    end if
+
+    ! Test with special characters that need escaping
+    diag%file_path = 'path\with"quotes\and\backslash.f90'
+    json = diag%to_json()
+
+    if (index(json, '"file"') == 0) then
+        print '(a)', 'FAIL: file key missing with special chars'
+        stop 1
+    end if
+
+    ! All tests passed
+    print '(a)', 'PASS'
+    stop 0
+
+end program test_json_filepath


### PR DESCRIPTION
Closes #248.

JSON output omitted the per-diagnostic source path. `diagnostic_to_json` now emits a `"file"` key (escaped, between `"category"` and `"location"`), matching the path SARIF already reports.

## Changes
- `src/fluff_diagnostics/fluff_diagnostics.f90`: emit `"file"` from `file_path` with JSON escaping; guard the allocatable.
- `test/test_json_filepath.f90`: presence, position, empty-path, and escaping cases.

## Verification
Before: JSON diagnostics had no `file` field; consumers could not map a diagnostic to its source file.

After:
```
$ fo test test_json_filepath
fo test [####################] 1/1 100%
$ fo test test_diagnostics
... OK
$ fo test test_combined_json
fo test [####################] 1/1 100%
```
`fo fmt --check`: clean (exit 0).