### PR TITLE
Add stdin support to fluff check and format

### DIFF
--- a/src/fluff_cli/fluff_cli.f90
+++ b/src/fluff_cli/fluff_cli.f90
@@ -28,6 +28,7 @@ module fluff_cli
         logical :: quiet = .false.
         logical :: verbose = .false.
         logical :: statistics = .false.
+        character(len=:), allocatable :: stdin_filename ! name for stdin input
         character(len=:), allocatable :: config_file
         character(len=:), allocatable :: output_format ! text, json, sarif
         character(len=:), allocatable :: error_msg ! Parse error message
@@ -76,6 +77,7 @@ contains
         ! Initialize
         this%command = "check" ! Default command
         this%error_msg = ""
+        this%stdin_filename = "stdin"
         expecting_value = .false.
         i = 1
 
@@ -87,6 +89,8 @@ contains
                     this%config_file = trim(argv(i))
                 case ("--output-format")
                     this%output_format = trim(argv(i))
+                case ("--stdin-filename")
+                    this%stdin_filename = trim(argv(i))
                 end select
                 expecting_value = .false.
 
@@ -119,7 +123,14 @@ contains
                 case ("--output-format")
                     current_flag = "--output-format"
                     expecting_value = .true.
+                case ("--stdin-filename")
+                    current_flag = "--stdin-filename"
+                    expecting_value = .true.
                 end select
+
+            else if (trim(argv(i)) == "-") then
+                ! Bare dash: read source from stdin
+                call add_file_to_list(this%files, "-")
 
             else if (len_trim(argv(i)) >= 1 .and. argv(i) (1:1) == "-") then
                 ! Short flags
@@ -174,6 +185,42 @@ contains
         end if
 
     end subroutine add_file_to_list
+
+    ! True when the request reads its single source from stdin ("-")
+    function args_use_stdin(args) result(use_stdin)
+        type(cli_args_t), intent(in) :: args
+        logical :: use_stdin
+
+        use_stdin = allocated(args%files)
+        if (use_stdin) use_stdin = size(args%files) == 1
+        if (use_stdin) use_stdin = trim(args%files(1)) == "-"
+
+    end function args_use_stdin
+
+    ! Read all of stdin verbatim, preserving trailing whitespace and newlines
+    subroutine read_stdin(content)
+        use, intrinsic :: iso_fortran_env, only: input_unit, iostat_end, &
+            iostat_eor
+        character(len=:), allocatable, intent(out) :: content
+
+        character(len=65536) :: buffer
+        integer :: nread, iostat_val
+
+        content = ""
+        do
+            read (input_unit, '(A)', advance="no", size=nread, &
+                iostat=iostat_val) buffer
+            if (nread > 0) content = content//buffer(1:nread)
+            if (iostat_val == iostat_eor) then
+                content = content//new_line('a')
+            else if (iostat_val == iostat_end) then
+                exit
+            else if (iostat_val /= 0) then
+                exit
+            end if
+        end do
+
+    end subroutine read_stdin
 
     ! Check if a path is a directory by attempting to list its contents
     function path_is_directory(path) result(is_dir)
@@ -379,6 +426,7 @@ contains
         type(diagnostic_t), allocatable :: all_diagnostics(:)
         character(len=:), allocatable :: error_msg
         character(len=:), allocatable :: expanded_files(:)
+        character(len=:), allocatable :: stdin_source
         integer :: i, fixes_applied
 
         exit_code = 0
@@ -393,6 +441,29 @@ contains
         ! Initialize linter
         call app%linter%initialize()
         call app%linter%set_config(config)
+
+        if (args_use_stdin(app%args)) then
+            call read_stdin(stdin_source)
+            call app%linter%lint_source(stdin_source, app%args%stdin_filename, &
+                diagnostics, error_msg)
+            if (error_msg /= "") then
+                print *, "Error linting stdin: ", error_msg
+                exit_code = 1
+            else if (allocated(diagnostics)) then
+                if (size(diagnostics) > 0) exit_code = 1
+                all_diagnostics = diagnostics
+            end if
+            if (.not. app%args%quiet) then
+                if (app%args%statistics) then
+                    call print_statistics(all_diagnostics, 1)
+                else if (allocated(all_diagnostics)) then
+                    call print_diagnostics(all_diagnostics, app%args%output_format)
+                else
+                    call print_diagnostics([diagnostic_t::], app%args%output_format)
+                end if
+            end if
+            return
+        end if
 
         ! Expand directories to their Fortran files
         if (allocated(app%args%files)) then
@@ -457,12 +528,30 @@ contains
         character(len=:), allocatable :: original_code
         character(len=:), allocatable :: error_msg
         character(len=:), allocatable :: expanded_files(:)
+        character(len=:), allocatable :: stdin_source
         integer :: i
 
         exit_code = 0
 
         ! Initialize formatter
         call app%formatter%initialize()
+
+        if (args_use_stdin(app%args)) then
+            call read_stdin(stdin_source)
+            call app%formatter%format_source(stdin_source, formatted_code, error_msg)
+            if (error_msg /= "") then
+                print *, "Error formatting stdin: ", error_msg
+                exit_code = 1
+            else if (app%args%check) then
+                if (formatted_code /= stdin_source) then
+                    print *, trim(app%args%stdin_filename), ": Would reformat"
+                    exit_code = 1
+                end if
+            else
+                write (*, '(A)', advance="no") formatted_code
+            end if
+            return
+        end if
 
         ! Expand directories to their Fortran files
         if (allocated(app%args%files)) then

--- a/src/fluff_linter/fluff_linter.f90
+++ b/src/fluff_linter/fluff_linter.f90
@@ -54,6 +54,7 @@ module fluff_linter
         procedure :: initialize => linter_initialize
         procedure :: set_config => linter_set_config
         procedure :: lint_file => linter_lint_file
+        procedure :: lint_source => linter_lint_source
         procedure :: lint_ast => linter_lint_ast
     end type linter_engine_t
 
@@ -100,9 +101,7 @@ contains
         type(diagnostic_t), allocatable, intent(out) :: diagnostics(:)
         character(len=:), allocatable, intent(out) :: error_msg
 
-        type(fluff_ast_context_t) :: ast_ctx
         character(len=:), allocatable :: source_code
-        character(len=1000) :: line
         integer :: unit, iostat
 
         ! Read file contents preserving trailing whitespace
@@ -130,6 +129,21 @@ contains
         end if
         close (unit)
 
+        call this%lint_source(source_code, filename, diagnostics, error_msg)
+
+    end subroutine linter_lint_file
+
+    ! Lint source already in memory, reporting under a virtual filename
+    subroutine linter_lint_source(this, source_code, filename, diagnostics, &
+            error_msg)
+        class(linter_engine_t), intent(inout) :: this
+        character(len=*), intent(in) :: source_code
+        character(len=*), intent(in) :: filename
+        type(diagnostic_t), allocatable, intent(out) :: diagnostics(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        type(fluff_ast_context_t) :: ast_ctx
+
         ! Parse AST fresh each time to avoid memory safety issues
         ! Note: Caching disabled due to shallow copy issues with AST context
         ! containing fortfront arena and semantic context with pointer components
@@ -150,7 +164,7 @@ contains
 
         error_msg = ""
 
-    end subroutine linter_lint_file
+    end subroutine linter_lint_source
 
     ! Lint an AST
     subroutine linter_lint_ast(this, ast_ctx, diagnostics)

--- a/test/test_stdin_input.f90
+++ b/test/test_stdin_input.f90
@@ -1,0 +1,122 @@
+program test_stdin_input
+    ! Test stdin support: lint_source entry point and "-" / --stdin-filename parsing
+    use fluff_diagnostics, only: diagnostic_t
+    use fluff_linter, only: create_linter_engine, linter_engine_t
+    use fluff_cli, only: cli_args_t
+    implicit none
+
+    print *, "Testing stdin input support..."
+
+    call test_lint_source_reports_violation()
+    call test_lint_source_clean()
+    call test_dash_parses_as_stdin()
+    call test_stdin_filename_flag()
+
+    print *, "[OK] All stdin input tests passed!"
+
+contains
+
+    subroutine test_lint_source_reports_violation()
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: source, error_msg
+        integer :: i
+        logical :: found_f001
+
+        source = "program test"//new_line('a')// &
+            "    integer :: x"//new_line('a')// &
+            "    x = 42"//new_line('a')// &
+            "end program test"
+
+        linter = create_linter_engine()
+        call linter%lint_source(source, "stdin", diagnostics, error_msg)
+
+        if (error_msg /= "") then
+            print *, "FAIL: lint_source error: ", error_msg
+            stop 1
+        end if
+
+        found_f001 = .false.
+        if (allocated(diagnostics)) then
+            do i = 1, size(diagnostics)
+                if (diagnostics(i)%code == "F001") found_f001 = .true.
+            end do
+        end if
+        if (.not. found_f001) then
+            print *, "FAIL: expected F001 from stdin source"
+            stop 1
+        end if
+    end subroutine test_lint_source_reports_violation
+
+    subroutine test_lint_source_clean()
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: source, error_msg
+        integer :: i
+        logical :: found_f001
+
+        source = "program test"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: x"//new_line('a')// &
+            "    x = 42"//new_line('a')// &
+            "end program test"
+
+        linter = create_linter_engine()
+        call linter%lint_source(source, "stdin", diagnostics, error_msg)
+
+        if (error_msg /= "") then
+            print *, "FAIL: lint_source error: ", error_msg
+            stop 1
+        end if
+
+        found_f001 = .false.
+        if (allocated(diagnostics)) then
+            do i = 1, size(diagnostics)
+                if (diagnostics(i)%code == "F001") found_f001 = .true.
+            end do
+        end if
+        if (found_f001) then
+            print *, "FAIL: unexpected F001 on clean source"
+            stop 1
+        end if
+    end subroutine test_lint_source_clean
+
+    subroutine test_dash_parses_as_stdin()
+        type(cli_args_t) :: args
+        character(len=32) :: argv(2)
+
+        argv(1) = "check"
+        argv(2) = "-"
+        call args%parse(2, argv)
+
+        if (.not. allocated(args%files)) then
+            print *, "FAIL: '-' did not produce a file entry"
+            stop 1
+        end if
+        if (size(args%files) /= 1 .or. trim(args%files(1)) /= "-") then
+            print *, "FAIL: '-' not recorded as stdin sentinel"
+            stop 1
+        end if
+        if (args%stdin_filename /= "stdin") then
+            print *, "FAIL: default stdin filename not 'stdin'"
+            stop 1
+        end if
+    end subroutine test_dash_parses_as_stdin
+
+    subroutine test_stdin_filename_flag()
+        type(cli_args_t) :: args
+        character(len=32) :: argv(4)
+
+        argv(1) = "check"
+        argv(2) = "--stdin-filename"
+        argv(3) = "buffer.f90"
+        argv(4) = "-"
+        call args%parse(4, argv)
+
+        if (args%stdin_filename /= "buffer.f90") then
+            print *, "FAIL: --stdin-filename not honored"
+            stop 1
+        end if
+    end subroutine test_stdin_filename_flag
+
+end program test_stdin_input


### PR DESCRIPTION
Closes #243.

`fluff check -` and `fluff format -` now read source from stdin, matching ruff. `-` is the stdin sentinel; the reported filename defaults to `stdin` and is overridable with `--stdin-filename NAME`. check writes diagnostics to stdout; format writes the formatted source to stdout.

## Changes
- `src/fluff_linter/fluff_linter.f90`: extract `lint_source(source, filename, ...)` from `lint_file` so in-memory source is linted under a virtual filename without a temp file; `lint_file` now reads then delegates.
- `src/fluff_cli/fluff_cli.f90`: parse bare `-` as a stdin file and `--stdin-filename`; `read_stdin` reads stdin verbatim (preserves trailing whitespace for F004); `check`/`format` branch to the stdin path.
- `test/test_stdin_input.f90`: `lint_source` reports/clears F001; `-` and `--stdin-filename` parsing.

## Verification
Before: `echo ... | fluff check -` printed `No files specified` and exited 1.

After (built binary):
```
$ printf 'program p\n  integer :: x\n  x = 1\nend program p\n' | fluff check -
stdin:1:1 [WARNING] Missing implicit none statement (F001)

$ printf 'program p\nimplicit none\ninteger::x\nx=1\nend program p\n' | fluff format -
program p
    implicit none
    integer :: x
    x = 1
end program p
```

Unit test:
```
$ fpm test test_stdin_input
 Testing stdin input support...
 [OK] All stdin input tests passed!
```

Note: `fo build` for the test target currently fails on `testdrive.mod` (lazy-fortran/fo#68, dev-dependency module resolution); the `src` build is clean (83/83) and the test was built and run via `fpm test` per the diagnose-fo-failure exception. `fo fmt --check`: clean.