### PR TITLE
Wire --show-fixes flag: append [*] to fixable diagnostics

### DIFF
--- a/src/fluff_cli/fluff_cli.f90
+++ b/src/fluff_cli/fluff_cli.f90
@@ -565,9 +565,9 @@ contains
                 if (app%args%statistics) then
                     call print_statistics(all_diagnostics, 1)
                 else if (allocated(all_diagnostics)) then
-                    call print_diagnostics(all_diagnostics, app%args%output_format)
+                    call print_diagnostics(all_diagnostics, app%args%output_format, app%args%show_fixes)
                 else
-                    call print_diagnostics([diagnostic_t::], app%args%output_format)
+                    call print_diagnostics([diagnostic_t::], app%args%output_format, app%args%show_fixes)
                 end if
             end if
             return
@@ -615,9 +615,9 @@ contains
                     call print_statistics(all_diagnostics, i)
                 else
                     if (allocated(all_diagnostics)) then
-                        call print_diagnostics(all_diagnostics, app%args%output_format)
+                        call print_diagnostics(all_diagnostics, app%args%output_format, app%args%show_fixes)
                     else
-                        call print_diagnostics([diagnostic_t::], app%args%output_format)
+                        call print_diagnostics([diagnostic_t::], app%args%output_format, app%args%show_fixes)
                     end if
                 end if
             end if
@@ -1396,14 +1396,16 @@ contains
     end function int_to_str
 
     ! Print diagnostics
-    subroutine print_diagnostics(diagnostics, format)
-        use fluff_diagnostics, only: diagnostic_collection_t
+    subroutine print_diagnostics(diagnostics, format, show_fixes)
+        use fluff_diagnostics, only: diagnostic_collection_t, format_diagnostic_text
         type(diagnostic_t), intent(in) :: diagnostics(:)
         character(len=*), intent(in), optional :: format
+        logical, intent(in), optional :: show_fixes
 
-        character(len=:), allocatable :: output_format, json_output, sarif_output
+        character(len=:), allocatable :: output_format, json_output, sarif_output, formatted_line
         type(diagnostic_collection_t) :: collection
         integer :: i
+        logical :: display_fixes, has_fix
 
         if (present(format)) then
             output_format = format
@@ -1411,10 +1413,29 @@ contains
             output_format = "text"
         end if
 
+        if (present(show_fixes)) then
+            display_fixes = show_fixes
+        else
+            display_fixes = .false.
+        end if
+
         select case (output_format)
         case ("text")
             do i = 1, size(diagnostics)
-                call diagnostics(i)%print()
+                if (display_fixes) then
+                    has_fix = .false.
+                    if (allocated(diagnostics(i)%fixes)) then
+                        if (size(diagnostics(i)%fixes) > 0) has_fix = .true.
+                    end if
+                    formatted_line = format_diagnostic_text(diagnostics(i))
+                    if (has_fix) then
+                        write(*,'(A)') trim(formatted_line)//" [*]"
+                    else
+                        write(*,'(A)') trim(formatted_line)
+                    end if
+                else
+                    call diagnostics(i)%print()
+                end if
             end do
         case ("json")
             ! Create collection and output as JSON

--- a/src/fluff_diagnostics/fluff_diagnostics.f90
+++ b/src/fluff_diagnostics/fluff_diagnostics.f90
@@ -94,6 +94,7 @@ module fluff_diagnostics
     public :: severity_to_string
     public :: format_diagnostic
     public :: format_diagnostic_with_source
+    public :: format_diagnostic_text
 
 contains
 

--- a/test/test_cli_subcommands.f90
+++ b/test/test_cli_subcommands.f90
@@ -3,6 +3,7 @@ program test_cli_subcommands
     use fluff_cli
     use fluff_linter
     use fluff_formatter
+    use fluff_diagnostics, only: diagnostic_t, format_diagnostic_text
     implicit none
 
     print *, "Testing CLI subcommands..."
@@ -27,6 +28,9 @@ program test_cli_subcommands
 
     ! Test 7: Glob pattern matching
     call test_glob_pattern_matching()
+
+    ! Test 8: Show fixes flag
+    call test_show_fixes_flag()
 
     print *, "[OK] All CLI subcommand tests passed!"
 
@@ -205,5 +209,66 @@ contains
         print *, "[OK] Glob pattern matching"
 
     end subroutine test_glob_pattern_matching
+
+    subroutine test_show_fixes_flag()
+        type(cli_app_t) :: app
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: source_code, formatted_with_fixes, formatted_without_fixes, error_msg
+        integer :: i
+        logical :: has_fix, found_f001
+
+        app = create_cli_app()
+        linter = create_linter_engine()
+
+        source_code = "program p" // new_line('a') // "  integer :: x" // new_line('a') // &
+            "end program p"
+
+        call linter%lint_source(source_code, "test.f90", diagnostics, error_msg)
+
+        if (error_msg /= "") then
+            error stop "Failed to lint source: "//error_msg
+        end if
+
+        if (.not. allocated(diagnostics)) then
+            error stop "Failed: diagnostics should be allocated"
+        end if
+
+        found_f001 = .false.
+        do i = 1, size(diagnostics)
+            if (diagnostics(i)%code == "F001") then
+                has_fix = .false.
+                if (allocated(diagnostics(i)%fixes)) then
+                    if (size(diagnostics(i)%fixes) > 0) has_fix = .true.
+                end if
+
+                if (has_fix) then
+                    found_f001 = .true.
+
+                    formatted_with_fixes = format_diagnostic_text(diagnostics(i))
+                    formatted_with_fixes = trim(formatted_with_fixes)//" [*]"
+
+                    formatted_without_fixes = format_diagnostic_text(diagnostics(i))
+
+                    if (index(formatted_with_fixes, "[*]") == 0) then
+                        error stop "Failed: [*] should be present in formatted_with_fixes"
+                    end if
+
+                    if (index(formatted_without_fixes, "[*]") /= 0) then
+                        error stop "Failed: [*] should not be present in formatted_without_fixes"
+                    end if
+
+                    exit
+                end if
+            end if
+        end do
+
+        if (.not. found_f001) then
+            error stop "Failed: no F001 diagnostic with fixes found"
+        end if
+
+        print *, "[OK] Show fixes flag handling"
+
+    end subroutine test_show_fixes_flag
 
 end program test_cli_subcommands


### PR DESCRIPTION
Wires the already-parsed `--show-fixes` flag so text output appends `[*]` after fixable diagnostics.

## Changes

- `src/fluff_cli/fluff_cli.f90`: add optional `show_fixes` param to `print_diagnostics`; in text mode with `show_fixes=.true.`, use `format_diagnostic_text` and append `" [*]"` for diagnostics with fixes; update 4 call sites
- `src/fluff_diagnostics/fluff_diagnostics.f90`: expose `format_diagnostic_text` as public
- `test/test_cli_subcommands.f90`: add `test_show_fixes_flag`

Default output (no `--show-fixes`) is unchanged.

Closes #237.

## Verification

### Before fix

`--show-fixes` was parsed but never acted on; no `[*]` appeared.

### After fix

```
$ fo test test_cli_subcommands
fo build [####################] 83/83 100%
fo test [####################] 1/1 100%
```