### PR TITLE
Emit fix suggestions (edits, is_safe) in JSON and SARIF output

### DIFF
--- a/src/fluff_diagnostics/fluff_diagnostics.f90
+++ b/src/fluff_diagnostics/fluff_diagnostics.f90
@@ -94,6 +94,7 @@ module fluff_diagnostics
     public :: severity_to_string
     public :: format_diagnostic
     public :: format_diagnostic_with_source
+    public :: format_diagnostic_sarif
     public :: format_diagnostic_text
 
 contains
@@ -189,6 +190,7 @@ contains
         class(diagnostic_t), intent(in) :: this
         character(len=:), allocatable :: json
         character(len=:), allocatable :: file_str
+        character(len=:), allocatable :: fixes_json
         character(len=20) :: line_str, col_str, end_line_str, end_col_str
 
         ! Convert integers to strings to avoid format issues
@@ -213,8 +215,16 @@ contains
             '  "location": {' // new_line('a') // &
             '    "start": {"line": ' // trim(line_str) // ', "column": ' // trim(col_str) // '},' // new_line('a') // &
             '    "end": {"line": ' // trim(end_line_str) // ', "column": ' // trim(end_col_str) // '}' // new_line('a') // &
-            '  }' // new_line('a') // &
-            '}'
+            '  }'
+
+        if (allocated(this%fixes)) then
+            if (size(this%fixes) > 0) then
+                fixes_json = fixes_to_json(this%fixes)
+                json = json // ',' // new_line('a') // '  "fixes": ' // fixes_json
+            end if
+        end if
+
+        json = json // new_line('a') // '}'
 
     end function diagnostic_to_json
 
@@ -545,6 +555,7 @@ contains
     function format_diagnostic_sarif(diagnostic) result(formatted)
         type(diagnostic_t), intent(in) :: diagnostic
         character(len=:), allocatable :: formatted
+        character(len=:), allocatable :: fixes_sarif
         character(len=20) :: start_line_str, start_col_str, end_line_str, end_col_str
 
         ! Convert integers to strings
@@ -565,8 +576,16 @@ contains
             ', "endLine": ' // trim(end_line_str) // &
             ', "endColumn": ' // trim(end_col_str) // '}' // new_line('a') // &
             '    }' // new_line('a') // &
-            '  }]' // new_line('a') // &
-            '}'
+            '  }]'
+
+        if (allocated(diagnostic%fixes)) then
+            if (size(diagnostic%fixes) > 0) then
+                fixes_sarif = fixes_to_sarif(diagnostic%fixes, diagnostic%file_path)
+                formatted = formatted // ',' // new_line('a') // '  "fixes": ' // fixes_sarif
+            end if
+        end if
+
+        formatted = formatted // new_line('a') // '}'
 
     end function format_diagnostic_sarif
 
@@ -937,5 +956,127 @@ contains
         escaped = buffer(1:j-1)
 
     end function escape_json_value
+
+    ! Convert fixes array to JSON format
+    function fixes_to_json(fixes) result(json)
+        type(fix_suggestion_t), intent(in) :: fixes(:)
+        character(len=:), allocatable :: json
+
+        character(len=:), allocatable :: buf
+        character(len=20) :: sl, sc, el, ec
+        integer :: i, j, n_fixes
+
+        allocate(character(len=10000) :: buf)
+        buf = "["
+        n_fixes = size(fixes)
+
+        do i = 1, n_fixes
+            if (i > 1) buf = buf // ","
+            buf = buf // new_line('a') // "      {"
+            buf = buf // new_line('a') // '        "description": "'
+
+            if (allocated(fixes(i)%description)) then
+                buf = buf // escape_json_value(fixes(i)%description)
+            end if
+            buf = buf // '",'
+
+            if (fixes(i)%is_safe) then
+                buf = buf // new_line('a') // '        "is_safe": true,'
+            else
+                buf = buf // new_line('a') // '        "is_safe": false,'
+            end if
+
+            buf = buf // new_line('a') // '        "edits": ['
+
+            if (allocated(fixes(i)%edits)) then
+                do j = 1, size(fixes(i)%edits)
+                    if (j > 1) buf = buf // ","
+                    write(sl, '(I0)') fixes(i)%edits(j)%range%start%line
+                    write(sc, '(I0)') fixes(i)%edits(j)%range%start%column
+                    write(el, '(I0)') fixes(i)%edits(j)%range%end%line
+                    write(ec, '(I0)') fixes(i)%edits(j)%range%end%column
+
+                    buf = buf // new_line('a') // '          {'
+                    buf = buf // new_line('a') // &
+                        '            "range": {"start": {"line": ' // trim(sl) // &
+                        ', "column": ' // trim(sc) // '}, "end": {"line": ' // &
+                        trim(el) // ', "column": ' // trim(ec) // '}},'
+                    buf = buf // new_line('a') // '            "new_text": "'
+
+                    if (allocated(fixes(i)%edits(j)%new_text)) then
+                        buf = buf // escape_json_value(fixes(i)%edits(j)%new_text)
+                    end if
+                    buf = buf // '"' // new_line('a') // '          }'
+                end do
+            end if
+
+            buf = buf // new_line('a') // '        ]' // new_line('a') // '      }'
+        end do
+
+        buf = buf // new_line('a') // "    ]"
+        json = trim(buf)
+
+    end function fixes_to_json
+
+    ! Convert fixes array to SARIF format
+    function fixes_to_sarif(fixes, file_path) result(sarif)
+        type(fix_suggestion_t), intent(in) :: fixes(:)
+        character(len=*), intent(in) :: file_path
+        character(len=:), allocatable :: sarif
+
+        character(len=:), allocatable :: buf
+        character(len=20) :: sl, sc, el, ec
+        integer :: i, j, n_fixes
+
+        allocate(character(len=10000) :: buf)
+        buf = "["
+        n_fixes = size(fixes)
+
+        do i = 1, n_fixes
+            if (i > 1) buf = buf // ","
+            buf = buf // new_line('a') // "      {"
+            buf = buf // new_line('a') // '        "description": {"text": "'
+
+            if (allocated(fixes(i)%description)) then
+                buf = buf // escape_json_value(fixes(i)%description)
+            end if
+            buf = buf // '"},'
+
+            buf = buf // new_line('a') // '        "artifactChanges": [{' // &
+                new_line('a') // '          "artifactLocation": {"uri": "' // &
+                trim(file_path) // '"},'
+
+            buf = buf // new_line('a') // '          "replacements": ['
+
+            if (allocated(fixes(i)%edits)) then
+                do j = 1, size(fixes(i)%edits)
+                    if (j > 1) buf = buf // ","
+                    write(sl, '(I0)') fixes(i)%edits(j)%range%start%line
+                    write(sc, '(I0)') fixes(i)%edits(j)%range%start%column
+                    write(el, '(I0)') fixes(i)%edits(j)%range%end%line
+                    write(ec, '(I0)') fixes(i)%edits(j)%range%end%column
+
+                    buf = buf // new_line('a') // '            {'
+                    buf = buf // new_line('a') // &
+                        '              "deletedRegion": {"startLine": ' // trim(sl) // &
+                        ', "startColumn": ' // trim(sc) // ', "endLine": ' // &
+                        trim(el) // ', "endColumn": ' // trim(ec) // '},'
+                    buf = buf // new_line('a') // '              "insertedContent": {"text": "'
+
+                    if (allocated(fixes(i)%edits(j)%new_text)) then
+                        buf = buf // escape_json_value(fixes(i)%edits(j)%new_text)
+                    end if
+                    buf = buf // '"}' // new_line('a') // '            }'
+                end do
+            end if
+
+            buf = buf // new_line('a') // '          ]' // &
+                new_line('a') // '        }]' // new_line('a') // '      }'
+        end do
+
+        buf = buf // new_line('a') // "    ]"
+        sarif = trim(buf)
+
+    end function fixes_to_sarif
 
 end module fluff_diagnostics

--- a/test/test_diagnostic_serialization.f90
+++ b/test/test_diagnostic_serialization.f90
@@ -1,0 +1,81 @@
+program test_diagnostic_serialization
+    use fluff_core, only: source_range_t, source_location_t
+    use fluff_diagnostics, only: diagnostic_t, fix_suggestion_t, text_edit_t, &
+        create_diagnostic, SEVERITY_WARNING, &
+        format_diagnostic_sarif
+    implicit none
+
+    call test_json_fix_output()
+
+contains
+
+    subroutine test_json_fix_output()
+        type(diagnostic_t) :: diag
+        type(fix_suggestion_t) :: fixes(1)
+        type(text_edit_t) :: edits(1)
+        type(source_location_t) :: start_pos, end_pos
+        type(source_range_t) :: loc_range, edit_range
+        character(len=:), allocatable :: json_output, sarif_output
+
+        ! Build diagnostic
+        start_pos%line = 1
+        start_pos%column = 1
+        end_pos%line = 1
+        end_pos%column = 1
+        loc_range%start = start_pos
+        loc_range%end = end_pos
+
+        diag = create_diagnostic("F001", "Missing implicit none", "test.f90", loc_range)
+
+        ! Build fix
+        edit_range%start = start_pos
+        edit_range%end = end_pos
+        edits(1)%range = edit_range
+        edits(1)%new_text = "implicit none"
+
+        fixes(1)%description = "add implicit none"
+        fixes(1)%is_safe = .true.
+        allocate(fixes(1)%edits(1))
+        fixes(1)%edits(1) = edits(1)
+
+        allocate(diag%fixes(1))
+        diag%fixes(1) = fixes(1)
+
+        ! Test JSON output
+        json_output = diag%to_json()
+
+        if (index(json_output, '"fixes"') == 0) then
+            error stop "[FAIL] JSON output missing fixes field"
+        end if
+
+        if (index(json_output, '"new_text"') == 0) then
+            error stop "[FAIL] JSON output missing new_text field"
+        end if
+
+        if (index(json_output, '"is_safe"') == 0) then
+            error stop "[FAIL] JSON output missing is_safe field"
+        end if
+
+        print *, "[OK] JSON fix output test passed"
+
+        ! Test SARIF output
+        sarif_output = format_diagnostic_sarif(diag)
+
+        if (index(sarif_output, '"fixes"') == 0) then
+            error stop "[FAIL] SARIF output missing fixes field"
+        end if
+
+        if (index(sarif_output, '"replacements"') == 0) then
+            error stop "[FAIL] SARIF output missing replacements field"
+        end if
+
+        if (index(sarif_output, '"deletedRegion"') == 0) then
+            error stop "[FAIL] SARIF output missing deletedRegion field"
+        end if
+
+        print *, "[OK] SARIF fix output test passed"
+        print *, "[OK] All JSON/SARIF fix output tests passed!"
+
+    end subroutine test_json_fix_output
+
+end program test_diagnostic_serialization


### PR DESCRIPTION
Extends `diagnostic_to_json` and `format_diagnostic_sarif` to include fix suggestions when a diagnostic carries them.

## Changes

- `src/fluff_diagnostics/fluff_diagnostics.f90`: append `"fixes"` array to JSON and SARIF when `diagnostic%fixes` is allocated and non-empty; add private helpers `fixes_to_json` and `fixes_to_sarif`
- `test/test_diagnostic_serialization.f90`: new test verifying JSON output contains `"fixes"`, `"new_text"`, `"is_safe"` and SARIF output contains `"fixes"`, `"replacements"`, `"deletedRegion"`

Text output unchanged. When no fixes, neither format changes.

Closes #246.

## Verification

### Before fix

`diagnostic_to_json` produced no `"fixes"` field.

### After fix

```
$ fo test test_diagnostic_serialization
fo build [####################] 83/83 100%
fo test [####################] 1/1 100%
```