### PR TITLE
Fix config rule ignore/select: load from namelist, apply in linter

### DIFF
--- a/src/fluff_config/fluff_config.f90
+++ b/src/fluff_config/fluff_config.f90
@@ -65,9 +65,6 @@ contains
         config%target_version = "2018"
         config%output_format = "text"
 
-        allocate (character(len=4) :: config%rules%select(1))
-        config%rules%select(1) = "F"
-
     end function create_default_config
 
     function load_config(config_file) result(config)
@@ -120,9 +117,11 @@ contains
         logical :: fix, show_fixes
         integer :: line_length, tab_width
         character(len=20) :: target_version, output_format
+        character(len=32) :: ignore(64), select(64)
+        character(len=:), allocatable :: ig_codes(:), sel_codes(:)
 
         namelist /fluff/ fix, show_fixes, line_length, tab_width, &
-            target_version, output_format
+            target_version, output_format, ignore, select
 
         if (present(error_msg)) error_msg = ""
 
@@ -134,6 +133,8 @@ contains
         output_format = ""
         if (allocated(this%target_version)) target_version = this%target_version
         if (allocated(this%output_format)) output_format = this%output_format
+        ignore = ''
+        select = ''
 
         open (newunit=unit, file=filename, status='old', action='read', &
             iostat=iostat)
@@ -156,6 +157,10 @@ contains
         this%tab_width = tab_width
         if (len_trim(target_version) > 0) this%target_version = trim(target_version)
         if (len_trim(output_format) > 0) this%output_format = trim(output_format)
+        ig_codes = collect_nonempty(ignore)
+        if (allocated(ig_codes)) this%rules%ignore = ig_codes
+        sel_codes = collect_nonempty(select)
+        if (allocated(sel_codes)) this%rules%select = sel_codes
 
     end subroutine config_from_file
 
@@ -168,9 +173,11 @@ contains
         logical :: fix, show_fixes
         integer :: line_length, tab_width
         character(len=20) :: target_version, output_format
+        character(len=32) :: ignore(64), select(64)
+        character(len=:), allocatable :: ig_codes(:), sel_codes(:)
 
         namelist /fluff/ fix, show_fixes, line_length, tab_width, &
-            target_version, output_format
+            target_version, output_format, ignore, select
 
         error_msg = ""
 
@@ -182,6 +189,8 @@ contains
         output_format = ""
         if (allocated(this%target_version)) target_version = this%target_version
         if (allocated(this%output_format)) output_format = this%output_format
+        ignore = ''
+        select = ''
 
         open (newunit=unit, status='scratch', form='formatted', action='readwrite')
         write (unit, '(A)') config_str
@@ -201,6 +210,10 @@ contains
         this%tab_width = tab_width
         if (len_trim(target_version) > 0) this%target_version = trim(target_version)
         if (len_trim(output_format) > 0) this%output_format = trim(output_format)
+        ig_codes = collect_nonempty(ignore)
+        if (allocated(ig_codes)) this%rules%ignore = ig_codes
+        sel_codes = collect_nonempty(select)
+        if (allocated(sel_codes)) this%rules%select = sel_codes
 
     end subroutine config_from_namelist_string
 
@@ -329,19 +342,26 @@ contains
         logical :: enabled
 
         integer :: i
+        logical :: have_select
 
-        enabled = .false.
-
+        have_select = .false.
         if (allocated(this%select)) then
+            if (size(this%select) > 0) have_select = .true.
+        end if
+
+        if (have_select) then
+            enabled = .false.
             do i = 1, size(this%select)
                 if (rule_matches_pattern(rule_code, this%select(i))) then
                     enabled = .true.
                     exit
                 end if
             end do
+        else
+            enabled = .true.
         end if
 
-        if (enabled .and. allocated(this%ignore)) then
+        if (allocated(this%ignore)) then
             do i = 1, size(this%ignore)
                 if (rule_matches_pattern(rule_code, this%ignore(i))) then
                     enabled = .false.
@@ -357,13 +377,37 @@ contains
         character(len=*), intent(in) :: pattern
         logical :: matches
 
-        if (len(pattern) <= len(rule_code)) then
-            matches = rule_code(1:len(pattern)) == pattern
+        integer :: plen
+        plen = len_trim(pattern)
+        if (plen > 0 .and. plen <= len_trim(rule_code)) then
+            matches = rule_code(1:plen) == pattern(1:plen)
         else
-            matches = .false.
+            matches = (plen == 0)
         end if
 
     end function rule_matches_pattern
+
+    function collect_nonempty(arr) result(codes)
+        character(len=*), intent(in) :: arr(:)
+        character(len=:), allocatable :: codes(:)
+        integer :: i, count, max_len
+
+        count = 0
+        max_len = 0
+        do i = 1, size(arr)
+            if (len_trim(arr(i)) == 0) exit
+            count = count + 1
+            if (len_trim(arr(i)) > max_len) max_len = len_trim(arr(i))
+        end do
+
+        if (count > 0) then
+            allocate (character(len=max_len) :: codes(count))
+            do i = 1, count
+                codes(i) = trim(arr(i))
+            end do
+        end if
+
+    end function collect_nonempty
 
     function validate_rule_codes(codes, invalid_code) result(valid)
         character(len=*), intent(in) :: codes(:)

--- a/src/fluff_linter/fluff_linter.f90
+++ b/src/fluff_linter/fluff_linter.f90
@@ -173,7 +173,8 @@ contains
         type(diagnostic_t), allocatable, intent(out) :: diagnostics(:)
 
         ! Run enabled rules on AST
-        call this%rule_registry%execute_rules(ast_ctx, diagnostics=diagnostics)
+        call this%rule_registry%execute_rules(ast_ctx, this%config%rules, &
+            diagnostics=diagnostics)
 
     end subroutine linter_lint_ast
 

--- a/test/test_config_schema.f90
+++ b/test/test_config_schema.f90
@@ -1,6 +1,8 @@
 program test_config_schema
     ! Test configuration schema validation and documentation
     use fluff_config
+    use fluff_diagnostics, only: diagnostic_t
+    use fluff_linter, only: create_linter_engine, linter_engine_t
     implicit none
 
     print *, "Testing configuration schema validation..."
@@ -16,6 +18,9 @@ program test_config_schema
 
     ! Test 4: Schema documentation
     call test_schema_documentation()
+
+    ! Test 5: Config ignore applied to linting
+    call test_config_ignore_applied()
 
     print *, "[OK] All configuration schema tests passed!"
 
@@ -144,5 +149,62 @@ contains
 
         print *, "[OK] Schema documentation"
     end subroutine test_schema_documentation
+
+    subroutine test_config_ignore_applied()
+        type(linter_engine_t) :: linter
+        type(fluff_config_t) :: config
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: error_msg, source
+        integer :: i
+        logical :: found_f001
+
+        source = "program p"//new_line('a')//"  integer :: x"//new_line('a')//"end program p"
+
+        linter = create_linter_engine()
+        call linter%lint_source(source, "test.f90", diagnostics, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: lint_source error: ", error_msg
+            stop 1
+        end if
+
+        found_f001 = .false.
+        if (allocated(diagnostics)) then
+            do i = 1, size(diagnostics)
+                if (diagnostics(i)%code == "F001") found_f001 = .true.
+            end do
+        end if
+        if (.not. found_f001) then
+            print *, "FAIL: expected F001 with default config"
+            stop 1
+        end if
+
+        config = create_default_config()
+        call config%from_namelist_string( &
+            "&fluff"//new_line('a')//"ignore = 'F001'"//new_line('a')//"/", error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: config_from_namelist_string error: ", error_msg
+            stop 1
+        end if
+        call linter%set_config(config)
+
+        call linter%lint_source(source, "test.f90", diagnostics, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: lint_source error (2): ", error_msg
+            stop 1
+        end if
+
+        found_f001 = .false.
+        if (allocated(diagnostics)) then
+            do i = 1, size(diagnostics)
+                if (diagnostics(i)%code == "F001") found_f001 = .true.
+            end do
+        end if
+        if (found_f001) then
+            print *, "FAIL: F001 should be suppressed by ignore"
+            stop 1
+        end if
+
+        print *, "[OK] Config ignore applied"
+    end subroutine test_config_ignore_applied
 
 end program test_config_schema


### PR DESCRIPTION
Fixes three bugs that caused `ignore`/`select` config to have no effect:

- **BUG A**: `linter_lint_ast` never passed `config%rules` to `execute_rules`, so selection was always ignored.
- **BUG B**: `selection_is_rule_enabled` treated empty `select` as "nothing enabled"; fixed to treat absent/empty select as "all rules enabled".
- **BUG C**: `config_from_file`/`config_from_namelist_string` did not read `ignore`/`select` from the namelist; added those variables and a `collect_nonempty` helper to populate `rules%ignore`/`rules%select`.

Also removes the stale `select = ["F"]` in `create_default_config` (it had no effect before BUG A was fixed; after the fix it would have silently disabled all non-F rules).

Namelist syntax:
```
&fluff
  ignore = 'F001'
  select = 'F003','F007'
/
```

## Verification
### Test fails on main
```
$ printf '&fluff\nignore = "F001"\n/\n' > /tmp/ignore.nml
$ printf 'program p\ninteger :: x\nend program p\n' > /tmp/viol.f90
$ fluff check --config /tmp/ignore.nml /tmp/viol.f90; echo "exit: $?"
/tmp/viol.f90:1:1 [WARNING] Missing implicit none statement (F001)
/tmp/viol.f90:1:1 [WARNING] Unused variable: x (F006)
exit: 1
```
F001 fires even though the config says to ignore it.

### Test passes after fix
```
$ fluff check --config /tmp/ignore.nml /tmp/viol.f90; echo "exit: $?"
/tmp/viol.f90:1:1 [WARNING] Unused variable: x (F006)
exit: 1
```
F001 suppressed; F006 (not ignored) still fires.

```
$ fo test test_config_schema
fo build [####################] 83/83 100%
fo test [####################] 1/1 100%
```
New `test_config_ignore_applied` subtest: lints with default config (F001 found), sets ignore = 'F001', lints again (F001 absent).