### PR TITLE
State fluff's role in the toolchain and correct false claims

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -423,15 +423,21 @@ end module
 
 ## Success Metrics
 
+These are design targets, not measured results. None of them is currently met,
+and nothing in the repository verifies them.
+
 ### Quality Metrics
-- **Zero false positives**: All diagnostics must be accurate
+- **Zero false positives**: All diagnostics must be accurate. Not met: #261
+  reports a false positive in F006 on subscripted array reads.
 - **Performance**: <1s analysis for 10K LOC
 - **Memory**: <100MB for typical projects
 
 ### Coverage Metrics
 - **Rule coverage**: 100% of documented rules
-- **Language coverage**: Full Fortran 2018 support
-- **Test coverage**: >90% line coverage
+- **Language coverage**: full support through the newest standard the
+  toolchain targets, which is Fortran 2023, not 2018
+- **Test coverage**: >90% line coverage. Not measured, and not currently
+  meaningful: 19 test programs cannot fail the build at all (#262).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,34 @@ The project is useful as a FortFront-based tool prototype, but it is not yet a
 Ruff-equivalent production tool. Several CLI and formatter features are still
 tracked as open issues.
 
+## Role in the toolchain
+
+`fluff` is the deep static-analysis half of a two-tool split, in the shape Go
+uses for `go vet` and staticcheck, Rust uses for cargo and clippy, and C and
+C++ use for compiler warnings and clang-tidy.
+
+`fo` owns the cheap tier: checks that need no parse tree, run on every
+invocation, and work with nothing else installed. Today that is unused imports,
+short-circuit reliance, and gfortran's own warnings.
+
+`fluff` owns every rule that needs an abstract syntax tree, because it is built
+on FortFront and `fo` is not. Type-aware rules, dead-code analysis, and
+column-major access patterns belong here. `fo lint --deep` reaches them by
+running `fluff check --output-format json` as a subprocess and merging the
+findings (lazy-fortran/fo#59).
+
+Two consequences worth stating explicitly:
+
+- Do not reimplement `fo`'s native rules here. They must keep working when
+  `fluff` is not installed.
+- The subprocess boundary is deliberate. It keeps `fo`'s dependency closure
+  free of FortFront, so `fo build` and `fo test` stay available during
+  bootstrap.
+
+Before `fo lint --deep` can rely on this repository, #260, #261, #262, and #263
+need to close. The test suite currently cannot fail (#262), so no claim made by
+a passing run here should be trusted yet.
+
 ## Current Scope
 
 Implemented or partially implemented:


### PR DESCRIPTION
## Why

Nothing recorded where fluff sits relative to fo. That gap has cost: fo accumulated 2,071 lines of native lint while this repository went untouched since May, and fo#59 specified a `--deep` tier without defining what makes a rule deep.

## The boundary

fluff is the deep half of a two-tool split, in the shape Go uses for `go vet`/staticcheck, Rust for cargo/clippy, C/C++ for compiler warnings/clang-tidy.

- **fo** owns checks needing no parse tree: unused imports, short-circuit reliance, gfortran warnings. Must work with fluff absent.
- **fluff** owns everything needing an AST. Reached via `fo lint --deep` running `fluff check --output-format json` as a subprocess.

The subprocess boundary is deliberate — it keeps fo's dependency closure free of FortFront so `fo build`/`fo test` stay available during bootstrap.

## Claims corrected

`DESIGN.md` listed these as quality/coverage metrics with nothing marking them unmet:

| Claim | Reality |
|---|---|
| "Zero false positives" | #261 — F006 flags `arr` as unused when it is read via `arr(i)` |
| "Full Fortran 2018 support" | the toolchain targets F2023 |
| ">90% line coverage" | unmeasured, and meaningless while 19 test programs cannot fail (#262) |

Now marked as targets, each naming what blocks it.

## Issues filed from this pass

Each reproduced against the current build before filing:

- **#260** — `fluff format` is not idempotent. Formatting already-correct source prepends a leading space to line 1 and rewrites `print *, i` into `print * , i`.
- **#261** — F006 ignores subscripted array reads. Verified scalars and written arrays behave correctly, so the gap is specifically the read-through-subscript path.
- **#262** — 19 test programs (8,148 lines) tally results, print `[FAIL]`, and exit 0. One carries the comment `! Individual test functions (should fail in RED phase)`.
- **#263** — `stdlib` declared but used zero times; FortFront pinned to floating `branch = "main"`.

#262 is the root cause of the other two: both #260 and #261 sit in areas these suites nominally cover.

## Verification

Docs only.

```
fo
Static: OK (178 modules)   Build: OK   Tests: OK   Lint: OK
All stages passed (10.4s)
```

Note that "Tests: OK" here is exactly the signal #262 says not to trust.

`check-writing-slop.py` reports the same 4 pre-existing flags as the baseline; this change introduces none.