### PR TITLE
Refresh the known-limits list against what the code actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Two consequences worth stating explicitly:
   bootstrap.
 
 Before `fo lint --deep` can rely on this repository, #260, #261, #262, and #263
-need to close. The test suite currently cannot fail (#262), so no claim made by
-a passing run here should be trusted yet.
+need to close. Take #262 first: while 28 test programs exit zero regardless of
+what they find, a passing run here is not evidence that the other three were
+fixed.
 
 ## Current Scope
 
@@ -45,16 +46,25 @@ Implemented or partially implemented:
 - formatter built on FortFront `emit_fortran`
 - basic LSP components
 - JSON/SARIF/GitHub-style output code paths
+- CLI: `--select`, `--ignore`, `--exclude`, `--statistics`, `--quiet`,
+  `--show-fixes`, the `rules` listing, and stdin input via `-`
 
 Known limits:
 
+- `fluff format` is not idempotent: it prepends a space to the first line and
+  writes `print * , i` for `print *, i` (#260)
+- `F006` reports an array as unused when it is only read through a subscript
+  (#261)
+- the test suite cannot detect either of the above, because 28 of its 94
+  programs exit zero no matter what they find (#262), and two more resolve the
+  binary under test by globbing fpm's build layout, so they can exercise a
+  stale artifact instead of the current tree (#265)
+- formatter can still move inline comments in unsafe ways (#244)
 - configuration support has open regressions
-- formatter can still move inline comments in unsafe ways
-- rule selection/ignore CLI parity with Ruff is incomplete
-- stdin, quiet mode, statistics, rule listing, and show-fixes UX are tracked as
-  open issues
 - AST caching is disabled in the linter path because FortFront arena/context
   copies are not yet safe enough
+  (`src/fluff_linter/fluff_linter.f90:83`), which leaves
+  `fluff_analysis_cache.f90` compiled but unreachable
 
 ## Install
 


### PR DESCRIPTION
## Why

The README's "known limits" listed six things as open issues that all work today. The 2026-06-28 CLI wave implemented them and the list was never updated, so the README understated the project.

## Verified by running, not by reading commit messages

| Listed as a limit | Actual |
|---|---|
| stdin | `fluff check -` works, reports `stdin:3:5` |
| quiet mode | `--quiet` suppresses output |
| statistics | `--statistics` prints occurrence counts |
| rule listing | `fluff rules` lists F001… |
| show-fixes | `--show-fixes` works |
| rule selection/ignore | `--select F006` and `--ignore F006` both filter correctly |

Replaced with limits that reproduce against `main` at `521fd91`: #260, #261, #262, #265. The AST-caching entry was accurate and stays, now citing `src/fluff_linter/fluff_linter.f90:83` and noting it leaves `fluff_analysis_cache.f90` (1,419 lines) compiled but unreachable.

## Something worth flagging from this pass

While verifying, `fo test` reported `main` as red — `test_combined_json` and `test_quiet_flag` failing. **It is not.** Both tests locate the binary by globbing `build/gfortran_*/app/fluff`, fpm's layout, while `fo` builds to `build/fo/app/fluff`. They were exercising a stale fpm artifact from before the June work:

```
$ rm -rf build/gfortran_*
$ fo test
Tests: 94 passed
```

Filed as #265. The direction that matters is the inverse of what happened here: a test that grades a binary it did not build will just as readily report green on a broken tree.

## Verification

```
fo test
Tests: 94 passed (1.4s)
```

`check-writing-slop.py` shows only the two pre-existing flags present in the baseline.