### PR TITLE
Test the fluff binary this build produced, not one found on disk

### DIFF
--- a/test/test_combined_json.f90
+++ b/test/test_combined_json.f90
@@ -1,25 +1,14 @@
 program test_combined_json
+    use test_support, only: resolve_fluff_binary
     implicit none
 
     character(len=:), allocatable :: bin_path, tmpdir, tmpout, output
-    character(len=1024) :: bin_buf, line
+    character(len=1024) :: line
     integer :: u, stat, ios, i, j
     integer :: extra_arrays
     logical :: has_file1, has_file2, in_string
 
-    call execute_command_line("ls build/gfortran_*/app/fluff > /tmp/fluff245_bin.txt 2>/dev/null", wait=.true.)
-    open(newunit=u, file="/tmp/fluff245_bin.txt", status="old", action="read", iostat=stat)
-    if (stat /= 0) then
-        print *, "FAIL: binary not found"
-        stop 1
-    end if
-    read(u, '(A)', iostat=stat) bin_buf
-    close(u)
-    if (stat /= 0 .or. len_trim(bin_buf) == 0) then
-        print *, "FAIL: binary not found"
-        stop 1
-    end if
-    bin_path = trim(bin_buf)
+    call resolve_fluff_binary(bin_path)
 
     tmpdir = "/tmp/fluff245_test_combined"
     call execute_command_line("rm -rf " // tmpdir // " && mkdir -p " // tmpdir, wait=.true.)

--- a/test/test_quiet_flag.f90
+++ b/test/test_quiet_flag.f90
@@ -1,25 +1,13 @@
 program test_quiet_flag
+    use test_support, only: resolve_fluff_binary
     implicit none
 
     character(len=:), allocatable :: bin_path, tmpdir, tmpfile, tmpfile_clean, tmpout
-    character(len=1024) :: bin_buf, line
+    character(len=1024) :: line
     integer :: u, stat, ios, exitstat
     logical :: file_exists
 
-    call execute_command_line("ls build/gfortran_*/app/fluff > /tmp/fluff242_bin.txt 2>/dev/null", &
-        wait=.true.)
-    open(newunit=u, file="/tmp/fluff242_bin.txt", status="old", action="read", iostat=stat)
-    if (stat /= 0) then
-        print *, "FAIL: binary not found"
-        stop 1
-    end if
-    read(u, '(A)', iostat=stat) bin_buf
-    close(u)
-    if (stat /= 0 .or. len_trim(bin_buf) == 0) then
-        print *, "FAIL: binary not found"
-        stop 1
-    end if
-    bin_path = trim(bin_buf)
+    call resolve_fluff_binary(bin_path)
 
     tmpdir = "/tmp/fluff242_test_quiet"
     call execute_command_line("rm -rf " // tmpdir // " && mkdir -p " // tmpdir, wait=.true.)

--- a/test/test_support.f90
+++ b/test/test_support.f90
@@ -13,6 +13,7 @@ module test_support
     public :: assert_has_diagnostic_code
     public :: assert_diagnostic_location
     public :: assert_equal_int
+    public :: resolve_fluff_binary
 
     integer(int64), parameter :: temp_path_clock_mod = 1000000000_int64
     integer(int64), save :: temp_path_last_clock = -1_int64
@@ -206,5 +207,55 @@ contains
             error stop 1
         end if
     end subroutine assert_equal_int
+
+    ! Locate the fluff executable belonging to the build that produced this
+    ! test program. The path is derived from the running test binary, so the
+    ! tool that compiled the test also supplies the binary under test. No
+    ! build layout is globbed and nothing found elsewhere on disk is accepted
+    ! as a substitute: an unresolvable binary aborts the caller instead of
+    ! letting it grade a foreign artifact.
+    subroutine resolve_fluff_binary(path)
+        character(len=:), allocatable, intent(out) :: path
+
+        character(len=4096) :: arg0
+        character(len=:), allocatable :: bin_dir
+        integer :: arg_len, arg_stat, slash
+        logical :: exists
+
+        call get_command_argument(0, arg0, length=arg_len, status=arg_stat)
+        if (arg_stat /= 0) call fail_binary_lookup("cannot read own argv[0]")
+        if (arg_len <= 0) call fail_binary_lookup("own argv[0] is empty")
+        if (arg_len > len(arg0)) call fail_binary_lookup("own argv[0] is too long")
+
+        slash = index(arg0(1:arg_len), "/", back=.true.)
+        if (slash <= 1) then
+            call fail_binary_lookup("test binary was invoked without a "// &
+                "directory: "//arg0(1:arg_len))
+        end if
+        bin_dir = arg0(1:slash - 1)
+
+        ! Executables and test programs share a directory under some backends
+        ! and sit in sibling directories under others; both candidates stay
+        ! inside the same build tree as this test program.
+        path = bin_dir//"/fluff"
+        inquire (file=path, exist=exists)
+        if (exists) return
+
+        path = bin_dir//"/../app/fluff"
+        inquire (file=path, exist=exists)
+        if (exists) return
+
+        call fail_binary_lookup("no fluff executable in the build that "// &
+            "produced this test, searched next to "//bin_dir)
+    end subroutine resolve_fluff_binary
+
+    subroutine fail_binary_lookup(reason)
+        character(len=*), intent(in) :: reason
+
+        write (error_unit, '(A)') "Failed: fluff binary under test not found: "// &
+            trim(reason)
+        flush (error_unit)
+        error stop 1
+    end subroutine fail_binary_lookup
 
 end module test_support


### PR DESCRIPTION
Closes #265.

## Problem

`test/test_quiet_flag.f90` and `test/test_combined_json.f90` resolved the executable under test with

```fortran
call execute_command_line("ls build/gfortran_*/app/fluff > /tmp/fluff242_bin.txt 2>/dev/null", wait=.true.)
```

That glob encodes one build tool's layout. Under the mandated `fo` loop the binary lands in `build/fo/`, so the glob never matched what had just been compiled; it matched whatever fpm artifact was still on disk. A test whose verdict comes from a build it did not produce is not measuring the tree. Issue #265 records it turning main red against a months-old binary, and it can as easily read green over a broken tree.

## Change

`test_support` gains `resolve_fluff_binary`, which derives the path from the test program's own `argv[0]`: whichever tool compiled the test also supplies the binary it exercises. Two candidates are tried, the test program's own directory and its sibling `app` directory, covering both build layouts without globbing either. Both stay inside the build tree the test came from. If neither exists the helper writes a message naming the directory it searched and `error stop 1` -- no fallback to anything else on disk.

The helper lives in `test_support` so future CLI tests inherit the guarantee instead of inventing another glob.

## Other instances

`grep` for `build/gfortran`, for `execute_command_line`, and for hardcoded build paths across `test/`, `src/`, and `app/` turns up no further test that locates a binary this way. The remaining `build/gfortran_*` references are not tests: `Dockerfile:27`, `.gitlab-ci.yml:36`, `INSTALL.md:62`, `docs/DEVELOPER_GUIDE.md:415,471`. They are documentation and packaging steps that never gate a test result, so they are left alone here and reported rather than folded in.

## Verification

Full pipeline: `fo` -> Static OK, Build OK, Tests OK (93 passed), Lint OK.

Negative controls, all run through `fo`:

1. **Stale binary is not picked up.** Planted an executable at `build/gfortran_0000STALE/app/fluff` that prints `STALE BINARY OUTPUT` and exits 0 -- it sorts ahead of the real fpm directory, so the old `ls` glob selects it. Pre-fix sources (`git stash push test/`): both tests FAIL, `FAIL: -q output not empty with violation` and `FAIL: first char is not [`. Post-fix with the same plant still in place: both PASS.
2. **The tests grade the current tree.** Injected `if (.true.) then` in place of `if (.not. app%args%quiet) then` at `src/fluff_cli/fluff_cli.f90:704` -> `test_quiet_flag` FAILs (`FAIL: -q output not empty with violation`); reverted -> PASS. Injected a leading space into the JSON write at `src/fluff_cli/fluff_cli.f90:1538` -> `test_combined_json` FAILs (`FAIL: leading space before [`); reverted -> PASS.
3. **No binary in this build means a loud failure, not a vacuous pass.** Moved `build/fo/bin/fluff` and `build/fo/app/fluff` aside while leaving the fpm artifacts on disk, then `fo exec --no-build`: both tests exit 1 with `Failed: fluff binary under test not found: no fluff executable in the build that produced this test, searched next to .../build/fo/bin`.
4. **Both resolution branches work.** With only `build/fo/bin/fluff` removed, the sibling `../app/fluff` candidate resolves and both tests PASS -- the same shape the fpm layout presents.