### PR TITLE
Stop the formatter splitting /=, ** and // into invalid Fortran

### DIFF
--- a/src/fluff_formatter/fluff_format_quality_improve.f90
+++ b/src/fluff_formatter/fluff_format_quality_improve.f90
@@ -183,10 +183,24 @@ contains
 
             select case (op)
             case ("+", "-", "*", "/")
-                if (op == "*" .and. pos < len(result) .and. &
-                    result(pos+1:pos+1) == "*") then
-                    pos = pos + 1
-                    cycle
+                ! Three Fortran operators begin with a character this routine
+                ! also treats as a complete operator: ** (power), // (concat)
+                ! and /= (not equal). Splitting one of them produces source
+                ! that does not compile and, worse, may mean something else:
+                ! `a /= b` became `a / = b` and `x**2` became `x* * 2`.
+                !
+                ! Skip past BOTH characters. The previous guard advanced by one,
+                ! landing on the second `*` of `**` and spacing that instead,
+                ! which is why the ** case was corrupted despite being guarded.
+                !
+                ! Note .and. does not short-circuit in Fortran, so the bounds
+                ! test cannot guard the substring reference in the same
+                ! expression; it is a separate statement.
+                if (pos < len(result)) then
+                    if (is_two_char_operator(op, result(pos + 1:pos + 1))) then
+                        pos = pos + 2
+                        cycle
+                    end if
                 end if
 
                 if (pos > 1 .and. result(pos-1:pos-1) /= " ") then
@@ -205,6 +219,22 @@ contains
         code = result
 
     end subroutine improve_operator_spacing
+
+    logical function is_two_char_operator(first, second)
+        !! True when first//second is a Fortran operator whose first character
+        !! is itself an operator: ** (power), // (concatenation), /= (not
+        !! equal). These must be stepped over whole, never spaced apart.
+        !!
+        !! <=, >=, ==, and => are not listed because their first character is
+        !! not one of the characters this routine spaces, so they never reach
+        !! here.
+        character, intent(in) :: first, second
+
+        is_two_char_operator = .false.
+        if (first == "*" .and. second == "*") is_two_char_operator = .true.
+        if (first == "/" .and. second == "/") is_two_char_operator = .true.
+        if (first == "/" .and. second == "=") is_two_char_operator = .true.
+    end function is_two_char_operator
 
     subroutine optimize_line_breaks(code, max_length)
         character(len=:), allocatable, intent(inout) :: code

--- a/test/test_operator_spacing_preserves_operators.f90
+++ b/test/test_operator_spacing_preserves_operators.f90
@@ -1,0 +1,65 @@
+program test_operator_spacing_preserves_operators
+    !! The operator-spacing pass must never split a Fortran operator whose first
+    !! character is itself an operator. It previously turned `a /= b` into
+    !! `a / = b` and `x**2` into `x* * 2`, which is not valid Fortran and, if it
+    !! were, would mean something else. See issue #270.
+    use fluff_format_quality_improve, only: apply_aesthetic_improvements
+    use fluff_format_quality_types, only: aesthetic_settings_t, &
+        create_aesthetic_settings
+    implicit none
+
+    integer :: n_pass, n_fail
+
+    n_pass = 0
+    n_fail = 0
+
+    call require_operator_survives('a /= b', '/=', 'not-equal')
+    call require_operator_survives('x = x**2', '**', 'power')
+    call require_operator_survives('s = "ab"//"cd"', '//', 'concatenation')
+
+    ! Single-character operators must still be spaced, or the pass would be
+    ! doing nothing and these tests would pass vacuously.
+    call require_spacing_applied('x=a+b', 'a + b', 'addition is spaced')
+    call require_spacing_applied('x=a*b', 'a * b', 'multiplication is spaced')
+
+    write (*, '(a,i0,a,i0,a)') 'operator_spacing: ', n_pass, ' pass, ', &
+        n_fail, ' fail'
+    if (n_fail > 0) error stop 1
+
+contains
+
+    subroutine assert(cond, msg)
+        logical, intent(in) :: cond
+        character(len=*), intent(in) :: msg
+
+        if (cond) then
+            n_pass = n_pass + 1
+        else
+            n_fail = n_fail + 1
+            write (*, '(a,a)') 'FAIL: ', msg
+        end if
+    end subroutine assert
+
+    subroutine require_operator_survives(source, op, name)
+        !! The operator must appear verbatim in the output, with its two
+        !! characters still adjacent.
+        character(len=*), intent(in) :: source, op, name
+        character(len=:), allocatable :: code
+
+        call apply_aesthetic_improvements(source, code, &
+            create_aesthetic_settings())
+        call assert(index(code, op) > 0, &
+            name//' operator survives spacing: got "'//trim(code)//'"')
+    end subroutine require_operator_survives
+
+    subroutine require_spacing_applied(source, expected, name)
+        character(len=*), intent(in) :: source, expected, name
+        character(len=:), allocatable :: code
+
+        call apply_aesthetic_improvements(source, code, &
+            create_aesthetic_settings())
+        call assert(index(code, expected) > 0, &
+            name//': expected "'//expected//'" in "'//trim(code)//'"')
+    end subroutine require_spacing_applied
+
+end program test_operator_spacing_preserves_operators


### PR DESCRIPTION
Closes #270.

## The defect

`fluff format` produced source that does not compile:

| input | output |
|---|---|
| `if (a /= b)` | `if (a / = b)` |
| `x = x**2` | `x = x * * 2` |
| `s = "ab"//"cd"` | `s = "ab" / / "cd"` |

Not a style disagreement — `/=` and `**` are destroyed, and if the result parsed it would mean something else.

## Root cause

`improve_operator_spacing` treats `+`, `-`, `*`, `/` as complete operators and inserts spaces around each. Three Fortran operators begin with one of those characters: `**`, `//`, `/=`.

The routine already guarded `**`:

```fortran
if (op == "*" .and. pos < len(result) .and. result(pos+1:pos+1) == "*") then
    pos = pos + 1
    cycle
end if
```

Two problems with it:

1. **It advances by one.** `pos + 1` lands *on* the second `*`, which then gets spaced. That is why `**` was corrupted despite being guarded.
2. **It relies on `.and.` short-circuiting.** Fortran does not short-circuit, so `result(pos+1:pos+1)` is evaluated even when `pos == len(result)` — the bounds test beside it protects nothing.

Fixed: step over both characters, cover all three operators, and make the bounds test a separate statement.

## Checked upstream first

fluff's formatter is built on FortFront's `emit_fortran`, so I verified there before touching fluff. **FortFront is correct** — it round-trips `/=` and `**` intact. The defect is entirely in this local post-processing pass.

Worth noting: fluff's README states the formatter "should not parse Fortran text itself", and this pass is exactly that.

## Regression test

`test/test_operator_spacing_preserves_operators.f90` asserts each operator survives, plus two assertions that single-character operators are *still* spaced — without those the test would pass against a pass that did nothing.

**Negative control**, guard removed:

```
FAIL: not-equal operator survives spacing: got "a / = b"
FAIL: power operator survives spacing: got "x = x * * 2"
FAIL: concatenation operator survives spacing: got "s = "ab" / / "cd""
operator_spacing: 2 pass, 3 fail
```

The two spacing assertions still pass under the fault, confirming they discriminate rather than tracking the same code path.

## Verification

```
fo
Static: OK (187 modules)   Build: OK   Tests: OK (95/95)   Lint: OK
All stages passed (9.9s)
```

## Not fixed here

`#260` remains open: the formatter is still non-idempotent, prepends a space to the first line, and writes `print * , i`. Those are cosmetic beside this one and want their own change.