### PR TITLE
Drop the unused stdlib dependency and pin FortFront to a revision

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -7,8 +7,7 @@ license = "MIT"
 copyright = "Copyright 2025, Christopher Albert"
 
 [dependencies]
-fortfront = { git = "https://github.com/lazy-fortran/fortfront.git", branch = "main" }
-stdlib = "*"
+fortfront = { git = "https://github.com/lazy-fortran/fortfront.git", rev = "b22d5654e9e457fad724040a290523a5f6b47c9a" }
 
 [dev-dependencies]
 test-drive = { git = "https://github.com/fortran-lang/test-drive.git" }


### PR DESCRIPTION
Closes #263.

## stdlib was declared and never used

```console
$ grep -rn "use stdlib" src app test | wc -l
0
```

One of the largest Fortran dependencies available, fetched and built on every clean build for nothing.

## FortFront was pinned to a floating branch

```toml
fortfront = { git = "...", branch = "main" }
```

Two builds of the same fluff commit were not the same program, and an upstream change could break fluff without either repository changing. That made every bug report against fluff ambiguous about which FortFront it was built on — which mattered directly while diagnosing #270 and #272.

Now pinned to `b22d5654e9e457fad724040a290523a5f6b47c9a`, matching how the roadmap records every other dependency in this toolchain. Moving the pin becomes a deliberate act.

## Verification

Built from scratch with `build/dependencies` removed, so the new pin was actually resolved rather than served from cache.

```
fo
Static: OK (187 modules)   Build: OK   Tests: OK   Lint: OK
All stages passed (9.2s)
```

One note for the record: the first clean build reported `test_visual_columns` failing, which did not reproduce on its own or on a repeat full run. The machine was concurrently running a four-suite ffc conformance regeneration at the time. Flagging it rather than omitting it, in case it recurs — a build-order or parallelism sensitivity would be worth its own issue if it does.