### PR TITLE
Count a subscripted array read as a use in F006

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Known limits:
 
 - `fluff format` is not idempotent: it prepends a space to the first line and
   writes `print * , i` for `print *, i` (#260)
-- `F006` reports an array as unused when it is only read through a subscript
-  (#261)
 - the test suite cannot detect either of the above, because 28 of its 94
   programs exit zero no matter what they find (#262), and two more resolve the
   binary under test by globbing fpm's build layout, so they can exercise a

--- a/src/fluff_rules/shared/fluff_rule_symbol_collect.f90
+++ b/src/fluff_rules/shared/fluff_rule_symbol_collect.f90
@@ -1,7 +1,7 @@
 module fluff_rule_symbol_collect
     use fluff_ast, only: fluff_ast_context_t
-    use fortfront, only: ast_arena_t, declaration_node, do_loop_node, &
-        function_def_node, get_children, identifier_node, &
+    use fortfront, only: ast_arena_t, call_or_subscript_node, declaration_node, &
+        do_loop_node, function_def_node, get_children, identifier_node, &
         parameter_declaration_node, program_node, &
         subroutine_def_node
     implicit none
@@ -246,6 +246,11 @@ contains
             var_name = ""
             select type (node => ctx%arena%entries(i)%node)
                 type is (identifier_node)
+                if (allocated(node%name)) var_name = node%name
+                type is (call_or_subscript_node)
+                ! arr(i) parses as a call-or-subscript, so the subscripted name
+                ! never reaches an identifier_node. Counting it here makes a
+                ! read of an array element a use of the array.
                 if (allocated(node%name)) var_name = node%name
             end select
 

--- a/test/test_rule_f006_unused_variable.f90
+++ b/test/test_rule_f006_unused_variable.f90
@@ -23,9 +23,116 @@ program test_rule_f006_unused_variable
     ! Test 5: Loop control variables should not trigger F006
     call test_loop_control_variables()
 
+    ! Issue #261 specification table, one fixture per row.
+    call test_declared_never_mentioned()
+    call test_declared_only_initialized()
+    call test_subscripted_read_never_written()
+    call test_array_written_then_read()
+
     print *, "[OK] All F006 tests passed!"
 
 contains
+
+    integer function f006_count_for(test_code, name_hint) result(count)
+        character(len=*), intent(in) :: test_code
+        character(len=*), intent(in) :: name_hint
+
+        type(linter_engine_t) :: linter
+        type(diagnostic_t), allocatable :: diagnostics(:)
+        character(len=:), allocatable :: tmpfile
+        integer :: k
+
+        call make_temp_fortran_path(name_hint, tmpfile)
+        linter = create_linter_engine()
+        call write_text_file(tmpfile, test_code)
+        call lint_file_checked(linter, tmpfile, diagnostics)
+
+        count = 0
+        if (allocated(diagnostics)) then
+            do k = 1, size(diagnostics)
+                if (diagnostics(k)%code == "F006") count = count + 1
+            end do
+        end if
+
+        call delete_file_if_exists(tmpfile)
+    end function f006_count_for
+
+    ! Row 1: declared, never mentioned -> flagged.
+    subroutine test_declared_never_mentioned()
+        character(len=:), allocatable :: test_code
+
+        test_code = "program test"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: vec(4), y"//new_line('a')// &
+            "    y = 1"//new_line('a')// &
+            "    print *, y"//new_line('a')// &
+            "end program test"
+
+        if (f006_count_for(test_code, "fluff_test_f006_silent") /= 1) then
+            error stop "Failed: F006 should flag an array that is never mentioned"
+        end if
+
+        print *, "[OK] Declared but never mentioned"
+    end subroutine test_declared_never_mentioned
+
+    ! Row 2: declared with an initializer and never referenced -> flagged.
+    subroutine test_declared_only_initialized()
+        character(len=:), allocatable :: test_code
+
+        test_code = "program test"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: x = 5"//new_line('a')// &
+            "    print *, 'hello'"//new_line('a')// &
+            "end program test"
+
+        if (f006_count_for(test_code, "fluff_test_f006_init") /= 1) then
+            error stop "Failed: F006 should flag a variable that is only initialized"
+        end if
+
+        print *, "[OK] Declared and only initialized"
+    end subroutine test_declared_only_initialized
+
+    ! Row 3: read through a subscript, never written -> not flagged.
+    ! Covers rank 1, 2 and 3, plain reads, reads inside an expression, reads in
+    ! a condition, and reads passed as an actual argument.
+    subroutine test_subscripted_read_never_written()
+        character(len=:), allocatable :: test_code
+
+        test_code = "program test"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: vec(4), mat(2, 2), cube(2, 2, 2), idx"//new_line('a')// &
+            "    idx = 1"//new_line('a')// &
+            "    print *, vec(idx)"//new_line('a')// &
+            "    print *, vec(idx) + mat(idx, idx)"//new_line('a')// &
+            "    if (mat(idx, idx) > 0) print *, 'positive'"//new_line('a')// &
+            "    print *, abs(cube(idx, idx, idx))"//new_line('a')// &
+            "end program test"
+
+        if (f006_count_for(test_code, "fluff_test_f006_subread") /= 0) then
+            error stop "Failed: a subscripted read must count as a use of the array"
+        end if
+
+        print *, "[OK] Subscripted read without a write"
+    end subroutine test_subscripted_read_never_written
+
+    ! Row 4: written through a subscript and then read -> not flagged.
+    subroutine test_array_written_then_read()
+        character(len=:), allocatable :: test_code
+
+        test_code = "program test"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: vec(4), idx"//new_line('a')// &
+            "    idx = 2"//new_line('a')// &
+            "    vec(idx) = 7"//new_line('a')// &
+            "    print *, vec(idx)"//new_line('a')// &
+            "end program test"
+
+        if (f006_count_for(test_code, "fluff_test_f006_rw") /= 0) then
+            error stop "Failed: F006 should not flag an array that is written and read"
+        end if
+
+        print *, "[OK] Array written then read"
+    end subroutine test_array_written_then_read
 
     subroutine test_unused_variable()
         type(linter_engine_t) :: linter


### PR DESCRIPTION
Closes #261.

## The bug

`collect_used_names` built the used-name set by scanning the arena for
`identifier_node`s. `arr(i)` is not an identifier: fortfront parses it as a
`call_or_subscript_node` carrying `name = "arr"` plus the subscript
arguments. The array name never entered the used set, so an array that was
only ever read through a subscript was reported unused.

That also explains the "adding a write fixes it" symptom from the issue:
whole-array forms (`arr = 0`, `sum(arr)`) and slices (`arr(1:2)`, whose base
is an identifier) do produce identifier nodes, so they were counted all along.

## The fix

One extra `select type` arm in `collect_used_names` records the
`call_or_subscript_node` name. Because fortfront produces that same node
shape wherever a subscripted reference appears, this covers every rank and
every context in one place: plain read, read inside an expression, read in a
condition, read passed as an actual argument.

A genuine function call also lands in the used set. That is harmless for
F006, since a declared variable cannot share its name with a procedure called
in the same scope.

## Tests

`test/test_rule_f006_unused_variable.f90` gains one fixture per row of the
issue's table:

| fixture | expectation |
|---|---|
| `test_declared_never_mentioned` | array never mentioned is flagged |
| `test_declared_only_initialized` | `integer :: x = 5`, never referenced, is flagged |
| `test_subscripted_read_never_written` | rank 1/2/3 reads in expressions, conditions and actual arguments are not flagged |
| `test_array_written_then_read` | not flagged |

Neutralising the new arm (making it record an empty name) turns
`test_subscripted_read_never_written` red with
`Failed: a subscripted read must count as a use of the array`, while the two
positive fixtures stay green — they do not depend on the new code path.

## Not breaking the rule

Full `fo` pipeline green. Run over the fortfront `examples/f90` corpus, the
change removes 20 F006 diagnostics and adds none; every removed name is an
array (`arr`, `mat`, `matrix`, `values`, `str_array`, ...). Genuinely unused
scalars and genuinely unmentioned arrays are still flagged, including
alongside heavy subscripted use in the same scope.

## Adjacent, not addressed here

A variable that is only ever written is not flagged today, whether the write
is `x = 5`, `arr = 0` or `arr(i) = 0`. Read/write discrimination is a
separate change with a much wider blast radius, so this PR keeps the existing
treatment and only stops the false positive on reads.