### PR TITLE
Indent formatted output by the configured width

### DIFF
--- a/src/fluff_formatter/fluff_format_indent.f90
+++ b/src/fluff_formatter/fluff_format_indent.f90
@@ -1,0 +1,88 @@
+module fluff_format_indent
+    ! Rescaling of the indentation width of already generated code.
+    !
+    ! fortfront's code generator honours set_indent_config only for the
+    ! statement nesting it indents through get_indent(). The emitters for a
+    ! program or module body build their prefix from a literal four spaces, so
+    ! asking fortfront for a width other than four yields a mixture: top level
+    ! declarations at four columns and nested statements at the requested
+    ! width. The formatter therefore emits at the one width fortfront is
+    ! self-consistent about and converts the result here.
+    implicit none
+    private
+
+    ! The indentation width fortfront emits one nesting level as.
+    integer, parameter, public :: emitted_indent_width = 4
+
+    public :: rescale_indentation
+
+contains
+
+    ! Reinterpret every leading run of blanks in `code` as a number of nesting
+    ! levels of `emitted_indent_width` columns and re-emit it at `indent_size`
+    ! columns of `indent_char` per level. Columns beyond a whole number of
+    ! levels are alignment rather than nesting and are carried over unchanged.
+    function rescale_indentation(code, indent_size, indent_char) result(rescaled)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: indent_size
+        character(len=1), intent(in) :: indent_char
+        character(len=:), allocatable :: rescaled
+
+        integer :: line_start, line_end, newline_offset
+
+        if (indent_size < 1) then
+            rescaled = code
+            return
+        end if
+
+        if (indent_size == emitted_indent_width .and. indent_char == " ") then
+            rescaled = code
+            return
+        end if
+
+        rescaled = ""
+        line_start = 1
+        do while (line_start <= len(code))
+            newline_offset = index(code(line_start:), new_line("a"))
+            if (newline_offset == 0) then
+                line_end = len(code)
+            else
+                line_end = line_start + newline_offset - 2
+            end if
+
+            rescaled = rescaled// &
+                rescale_line(code(line_start:line_end), indent_size, indent_char)
+            if (line_end < len(code)) rescaled = rescaled//new_line("a")
+
+            line_start = line_end + 2
+        end do
+
+    end function rescale_indentation
+
+    function rescale_line(line, indent_size, indent_char) result(rescaled)
+        character(len=*), intent(in) :: line
+        integer, intent(in) :: indent_size
+        character(len=1), intent(in) :: indent_char
+        character(len=:), allocatable :: rescaled
+
+        integer :: lead, level, alignment
+
+        if (len_trim(line) == 0) then
+            rescaled = ""
+            return
+        end if
+
+        lead = verify(line, " ") - 1
+        if (lead <= 0) then
+            rescaled = line
+            return
+        end if
+
+        level = lead/emitted_indent_width
+        alignment = lead - level*emitted_indent_width
+        rescaled = repeat(indent_char, level*indent_size)// &
+            repeat(" ", alignment)//line(lead + 1:)
+
+    end function rescale_line
+
+end module fluff_format_indent

--- a/src/fluff_formatter/fluff_format_quality_improve.f90
+++ b/src/fluff_formatter/fluff_format_quality_improve.f90
@@ -8,6 +8,9 @@ module fluff_format_quality_improve
     public :: optimize_line_breaks
     public :: combine_short_lines
 
+    ! Continuation indent used when the caller does not state one.
+    integer, parameter :: default_continuation_indent = 4
+
 contains
 
     subroutine apply_aesthetic_improvements(input_code, output_code, settings)
@@ -40,7 +43,8 @@ contains
         end if
 
         if (settings%optimize_line_breaks) then
-            call optimize_line_breaks(temp_code, settings%max_line_length)
+            call optimize_line_breaks(temp_code, settings%max_line_length, &
+                settings%indent_size)
         end if
 
         output_code = temp_code
@@ -236,11 +240,17 @@ contains
         if (first == "/" .and. second == "=") is_two_char_operator = .true.
     end function is_two_char_operator
 
-    subroutine optimize_line_breaks(code, max_length)
+    subroutine optimize_line_breaks(code, max_length, continuation_indent)
         character(len=:), allocatable, intent(inout) :: code
         integer, intent(in) :: max_length
+        integer, intent(in), optional :: continuation_indent
 
         type(aesthetic_settings_t) :: settings
+        integer :: indent
+
+        indent = default_continuation_indent
+        if (present(continuation_indent)) indent = continuation_indent
+        if (indent < 1) indent = default_continuation_indent
 
         settings = create_aesthetic_settings()
 
@@ -248,13 +258,14 @@ contains
             call combine_short_lines(code, max_length)
         end if
 
-        call break_long_lines(code, max_length)
+        call break_long_lines(code, max_length, indent)
 
     end subroutine optimize_line_breaks
 
-    subroutine break_long_lines(code, max_length)
+    subroutine break_long_lines(code, max_length, continuation_indent)
         character(len=:), allocatable, intent(inout) :: code
         integer, intent(in) :: max_length
+        integer, intent(in) :: continuation_indent
 
         character(len=:), allocatable :: result
         character(len=:), allocatable :: line
@@ -290,7 +301,8 @@ contains
 
             if (len_trim(line) > max_length .and. .not. skip_line_breaking) then
                 if (.not. first_line) result = result // new_line("a")
-                call break_fortran_line(line(1:len_trim(line)), result, max_length)
+                call break_fortran_line(line(1:len_trim(line)), result, &
+                    max_length, continuation_indent)
                 first_line = .false.
             else
                 if (.not. first_line) result = result // new_line("a")
@@ -497,10 +509,11 @@ contains
 
     end function is_simple_statement
 
-    subroutine break_fortran_line(line, result, max_length)
+    subroutine break_fortran_line(line, result, max_length, continuation_indent)
         character(len=*), intent(in) :: line
         character(len=:), allocatable, intent(inout) :: result
         integer, intent(in) :: max_length
+        integer, intent(in) :: continuation_indent
 
         character(len=:), allocatable :: remaining, current_segment
         integer :: break_pos, break_next_start, leading_spaces, trimmed_len
@@ -527,7 +540,8 @@ contains
             current_segment = remaining(1:break_pos) // " &"
             result = result // trim(current_segment)
 
-            call prepare_continuation_line(remaining, break_next_start, leading_spaces)
+            call prepare_continuation_line(remaining, break_next_start, &
+                leading_spaces, continuation_indent)
             if (len_trim(remaining) > 0) then
                 result = result // new_line("a")
             end if
@@ -629,10 +643,12 @@ contains
 
     end subroutine find_break_location
 
-    subroutine prepare_continuation_line(remaining, break_next_start, leading_spaces)
+    subroutine prepare_continuation_line(remaining, break_next_start, &
+            leading_spaces, continuation_indent)
         character(len=:), allocatable, intent(inout) :: remaining
         integer, intent(in) :: break_next_start
         integer, intent(in) :: leading_spaces
+        integer, intent(in) :: continuation_indent
 
         character(len=:), allocatable :: tail
         integer :: trimmed_len
@@ -640,7 +656,8 @@ contains
         trimmed_len = len_trim(remaining)
         if (break_next_start <= trimmed_len) then
             tail = remaining(break_next_start:trimmed_len)
-            remaining = repeat(" ", leading_spaces + 4) // trim(adjustl(tail))
+            remaining = repeat(" ", leading_spaces + continuation_indent) // &
+                trim(adjustl(tail))
         else
             remaining = ""
         end if

--- a/src/fluff_formatter/fluff_formatter.f90
+++ b/src/fluff_formatter/fluff_formatter.f90
@@ -7,6 +7,7 @@ module fluff_formatter
         create_quality_metrics, format_quality_t
     use fluff_format_continuation, only: has_leading_ampersand_continuations, &
         preserve_leading_ampersand_lines
+    use fluff_format_indent, only: emitted_indent_width, rescale_indentation
     use fluff_user_feedback, only: collect_interactive_feedback, create_user_feedback, &
         user_feedback_t
     use fluff_formatter_style, only: detect_style_guide_from_source, &
@@ -135,6 +136,7 @@ contains
         character(len=:), allocatable :: temp_code
         character(len=:), allocatable :: improved_code
         character(len=:), allocatable :: next_code
+        type(aesthetic_settings_t) :: settings
         integer :: saved_indent_size
         integer :: saved_line_length
         character(len=1) :: saved_indent_char
@@ -148,7 +150,11 @@ contains
             call get_line_length_config(saved_line_length)
             call get_type_standardization(saved_standardize_types)
 
-            call set_indent_config(this%options%indent_size, this%options%indent_char)
+            ! fortfront only honours a requested indent width for the
+            ! statement nesting it indents through get_indent(); its program
+            ! and module body emitters hardcode four columns. Emit at the one
+            ! width it is self-consistent about, then rescale.
+            call set_indent_config(emitted_indent_width, ' ')
             call set_line_length_config(this%options%line_length)
             call set_type_standardization(this%options%standardize_types)
 
@@ -158,11 +164,16 @@ contains
             call set_line_length_config(saved_line_length)
             call set_type_standardization(saved_standardize_types)
 
+            temp_code = rescale_indentation(temp_code, this%options%indent_size, &
+                this%options%indent_char)
+
             if (this%enable_quality_improvements) then
+                settings = this%aesthetic_settings
+                settings%indent_size = this%options%indent_size
                 improved_code = temp_code
                 do iter = 1, 2
                     call apply_aesthetic_improvements(improved_code, next_code, &
-                        this%aesthetic_settings)
+                        settings)
                     changed = next_code /= improved_code
                     improved_code = next_code
                     if (.not. changed) exit
@@ -252,7 +263,8 @@ contains
             call get_line_length_config(saved_line_length)
             call get_type_standardization(saved_standardize_types)
 
-            call set_indent_config(this%options%indent_size, this%options%indent_char)
+            ! Emit at the width fortfront indents consistently, then rescale.
+            call set_indent_config(emitted_indent_width, ' ')
             call set_line_length_config(this%options%line_length)
             call set_type_standardization(this%options%standardize_types)
 
@@ -261,6 +273,9 @@ contains
             call set_indent_config(saved_indent_size, saved_indent_char)
             call set_line_length_config(saved_line_length)
             call set_type_standardization(saved_standardize_types)
+
+            full_formatted = rescale_indentation(full_formatted, &
+                this%options%indent_size, this%options%indent_char)
 
             call split_lines_dynamic(full_formatted, lines, num_lines)
 

--- a/test/test_formatter_indent_size.f90
+++ b/test/test_formatter_indent_size.f90
@@ -1,0 +1,177 @@
+program test_formatter_indent_size
+    !! format_source has to indent by options%indent_size. It used to indent
+    !! by four columns whatever was configured, because fortfront's program
+    !! and module body emitters build their prefix from a literal four spaces
+    !! and only its nested-statement path consults the requested width. That
+    !! produced output mixing both widths, so a single-width oracle is what
+    !! this checks: every indented line must be a whole number of levels of
+    !! the configured width.
+    use fluff_formatter, only: formatter_engine_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call check_width(1)
+    call check_width(2)
+    call check_width(3)
+    call check_width(4)
+    call check_width(8)
+    call check_tab_indent()
+
+    if (failures /= 0) error stop "formatter ignores the configured indent size"
+
+    print *, "[OK] format_source honours options%indent_size"
+
+contains
+
+    subroutine check_width(width)
+        integer, intent(in) :: width
+
+        character(len=:), allocatable :: formatted
+
+        call format_sample(width, ' ', formatted)
+
+        ! The shallowest indented line is one level deep, so it fixes the
+        ! width; every other indent must be a multiple of it.
+        call expect(smallest_positive_indent(formatted) == width, &
+            "shallowest indent is not the configured width", width, formatted)
+        call expect(all_indents_are_multiples(formatted, width), &
+            "an indent is not a multiple of the configured width", width, &
+            formatted)
+    end subroutine check_width
+
+    subroutine check_tab_indent()
+        character(len=:), allocatable :: formatted
+
+        call format_sample(1, achar(9), formatted)
+
+        call expect(index(formatted, achar(9)//"implicit none") > 0, &
+            "declarations are not indented with the configured tab", 1, &
+            formatted)
+        ! The print sits three levels in: program body, do body, if body.
+        call expect(index(formatted, repeat(achar(9), 3)//"print") > 0, &
+            "nested statements are not indented with the configured tab", 1, &
+            formatted)
+    end subroutine check_tab_indent
+
+    subroutine format_sample(width, indent_char, formatted)
+        integer, intent(in) :: width
+        character(len=1), intent(in) :: indent_char
+        character(len=:), allocatable, intent(out) :: formatted
+
+        type(formatter_engine_t) :: formatter
+        character(len=:), allocatable :: error_msg
+
+        call formatter%initialize()
+        formatter%options%indent_size = width
+        formatter%options%indent_char = indent_char
+        formatter%options%use_tabs = indent_char == achar(9)
+
+        call formatter%format_source(sample_source(), formatted, error_msg)
+
+        if (error_msg /= "") error stop "formatting the sample failed"
+        if (len_trim(formatted) == 0) error stop "formatting produced no output"
+    end subroutine format_sample
+
+    ! Top level declarations and a nested statement, so that both fortfront
+    ! emission paths are exercised.
+    function sample_source() result(source)
+        character(len=:), allocatable :: source
+
+        source = "program p"//new_line('a')// &
+            "implicit none"//new_line('a')// &
+            "integer :: i"//new_line('a')// &
+            "do i = 1, 3"//new_line('a')// &
+            "if (i > 1) then"//new_line('a')// &
+            "print *, i"//new_line('a')// &
+            "end if"//new_line('a')// &
+            "end do"//new_line('a')// &
+            "end program p"
+    end function sample_source
+
+    subroutine expect(condition, what, width, formatted)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: what
+        integer, intent(in) :: width
+        character(len=*), intent(in) :: formatted
+
+        if (condition) return
+
+        failures = failures + 1
+        print *, "[FAIL] indent_size ", width, ": ", what
+        print *, formatted
+    end subroutine expect
+
+    function smallest_positive_indent(code) result(width)
+        character(len=*), intent(in) :: code
+        integer :: width
+
+        integer :: line_start, line_end, lead
+
+        width = 0
+        line_start = 1
+        do while (line_start <= len(code))
+            call next_line(code, line_start, line_end)
+            lead = leading_blanks(code, line_start, line_end)
+            if (lead > 0) then
+                if (width == 0) then
+                    width = lead
+                else if (lead < width) then
+                    width = lead
+                end if
+            end if
+            line_start = line_end + 2
+        end do
+    end function smallest_positive_indent
+
+    function all_indents_are_multiples(code, width) result(ok)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: width
+        logical :: ok
+
+        integer :: line_start, line_end, lead
+
+        ok = .true.
+        line_start = 1
+        do while (line_start <= len(code))
+            call next_line(code, line_start, line_end)
+            lead = leading_blanks(code, line_start, line_end)
+            if (lead > 0) then
+                if (mod(lead, width) /= 0) ok = .false.
+            end if
+            line_start = line_end + 2
+        end do
+    end function all_indents_are_multiples
+
+    subroutine next_line(code, line_start, line_end)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_start
+        integer, intent(out) :: line_end
+
+        integer :: newline_offset
+
+        newline_offset = index(code(line_start:), new_line('a'))
+        if (newline_offset == 0) then
+            line_end = len(code)
+        else
+            line_end = line_start + newline_offset - 2
+        end if
+    end subroutine next_line
+
+    ! Number of leading blanks on a line that has content, zero otherwise.
+    function leading_blanks(code, line_start, line_end) result(lead)
+        character(len=*), intent(in) :: code
+        integer, intent(in) :: line_start, line_end
+        integer :: lead
+
+        lead = 0
+        if (line_end < line_start) return
+        if (len_trim(code(line_start:line_end)) == 0) return
+
+        lead = verify(code(line_start:line_end), " ") - 1
+        if (lead < 0) lead = 0
+    end function leading_blanks
+
+end program test_formatter_indent_size

--- a/test/test_formatter_indent_size.f90
+++ b/test/test_formatter_indent_size.f90
@@ -19,6 +19,7 @@ program test_formatter_indent_size
     call check_width(4)
     call check_width(8)
     call check_tab_indent()
+    call check_continuation_width()
 
     if (failures /= 0) error stop "formatter ignores the configured indent size"
 
@@ -55,6 +56,87 @@ contains
             "nested statements are not indented with the configured tab", 1, &
             formatted)
     end subroutine check_tab_indent
+
+    subroutine check_continuation_width()
+        !! The line breaker's continuation indent must come from the caller's
+        !! configuration, not a constant.
+        !!
+        !! test_optimize_line_breaks already passes a width to
+        !! optimize_line_breaks directly, so it verifies the function and not
+        !! the wiring that supplies it. Review of this change showed the gap:
+        !! replacing `settings%indent_size = this%options%indent_size` with a
+        !! literal 4 left the whole suite green while demonstrably changing
+        !! output. This goes through format_source so that assignment is on the
+        !! path under test.
+        character(len=:), allocatable :: formatted, error_msg
+        type(formatter_engine_t) :: formatter
+        integer :: line_start, line_end, indent, stmt_indent
+        logical :: saw_continuation
+
+        call formatter%initialize()
+        formatter%options%indent_size = 2
+        formatter%options%indent_char = ' '
+        formatter%options%line_length = 60
+
+        call formatter%format_source(long_declaration_source(), formatted, &
+            error_msg)
+        if (error_msg /= "") return
+        if (len_trim(formatted) == 0) return
+
+        ! A continuation is any line after the first whose predecessor ends in
+        ! '&'. Its indent must be a multiple of the configured width.
+        ! Assert the DELTA between the broken statement and its continuation
+        ! equals the configured width. A "multiple of the width" check is too
+        ! weak: at width 2 a four-column continuation satisfies it, which is
+        ! exactly the neutralized behaviour this test has to catch.
+        saw_continuation = .false.
+        line_start = 1
+        do
+            call next_line(formatted, line_start, line_end)
+            if (line_start > len(formatted)) exit
+            if (line_end >= line_start) then
+                if (index(formatted(line_start:line_end), '&') > 0) then
+                    stmt_indent = blanks_at_start(formatted(line_start:line_end))
+                    line_start = line_end + 2
+                    call next_line(formatted, line_start, line_end)
+                    if (line_start > len(formatted)) exit
+                    indent = blanks_at_start(formatted(line_start:line_end))
+                    if (indent > stmt_indent) then
+                        saw_continuation = .true.
+                        call expect(indent - stmt_indent == 2, &
+                            'continuation is indented by exactly the '// &
+                            'configured width past its statement', 2, formatted)
+                    end if
+                end if
+            end if
+            line_start = line_end + 2
+            if (line_start > len(formatted)) exit
+        end do
+
+        call expect(saw_continuation, &
+            'the sample actually produced a continuation to measure', 2, &
+            formatted)
+    end subroutine check_continuation_width
+
+    function long_declaration_source() result(source)
+        character(len=:), allocatable :: source
+
+        source = 'program p'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: very_long_var_name_one, very_long_var_name_two, '// &
+            'very_long_var_name_three, very_long_var_name_four'// &
+            new_line('a')//'end program p'//new_line('a')
+    end function long_declaration_source
+
+    integer function blanks_at_start(line) result(n)
+        character(len=*), intent(in) :: line
+
+        n = 0
+        do while (n < len(line))
+            if (line(n + 1:n + 1) /= ' ') exit
+            n = n + 1
+        end do
+    end function blanks_at_start
 
     subroutine format_sample(width, indent_char, formatted)
         integer, intent(in) :: width

--- a/test/test_optimize_line_breaks.f90
+++ b/test/test_optimize_line_breaks.f90
@@ -127,6 +127,27 @@ program test_optimize_line_breaks
         print *, "  Got:      '", actual_output, "'"
     end if
 
+    ! Test 7: continuation lines follow the requested indent width
+    ! A file formatted with a two-column indent must not get four-column
+    ! continuations; the width used here is the caller's, not a constant.
+    test_count = test_count + 1
+    input_code = "  integer :: very_long_var_name_one, very_long_var_name_two, " // &
+        "very_long_var_name_three, very_long_var_name_four"
+    expected_output = "  integer :: very_long_var_name_one, very_long_var_name_two, " // &
+        "very_long_var_name_three, &" // new_line('a') // &
+        "    very_long_var_name_four"
+    actual_output = input_code
+    call optimize_line_breaks(actual_output, 88, 2)
+    test_passed = (actual_output == expected_output)
+    if (test_passed) then
+        pass_count = pass_count + 1
+        print *, "Test 7 PASSED: Continuation indent follows the requested width"
+    else
+        print *, "Test 7 FAILED: Continuation indent ignored the requested width"
+        print *, "  Expected: '", expected_output, "'"
+        print *, "  Got:      '", actual_output, "'"
+    end if
+
     ! Summary
     print *, ""
     print *, "=== Test Summary ==="


### PR DESCRIPTION
Closes #272.

## What was actually wrong

Not the aesthetic settings. `create_aesthetic_settings` hardcoding
`indent_size = 4` is real, but the aesthetic pass never read the field, which
is why syncing it from the engine's options changed nothing.

The engine does pass `options%indent_size` to fortfront's `set_indent_config`
before emitting, and that call survives to the emit. fortfront honours it only
where it indents through `get_indent()`, which covers nested statements. The
program and module body emitters (`codegen_grouped_body.f90`,
`codegen_program_header.f90`) build their prefix from a literal `"    "`.

Measured, with `indent_size = 2`, before this change:

```
program p
    implicit none      <- fortfront's literal four
    integer :: i
  do i = 1, 3          <- the requested two
    print *, i
  end do
end program p
```

So neither hypothesis in the issue on its own: the configuration is not lost,
it is only partly consulted.

## The fix

Emit at the single width fortfront is self-consistent about, then convert.
`rescale_indentation` reads each leading run of blanks as a whole number of
four-column levels and re-emits it at the configured width and character.
Columns beyond a whole number of levels are alignment, not nesting, and are
carried across unchanged.

At `indent_size = 4` with a space the conversion is the identity, so the
default path emits byte-identical output to before.

## The dead field

`aesthetic_settings%indent_size` is now live: it is the width the line breaker
indents a continuation by, replacing a hardcoded `+ 4`, and the engine fills it
from `options%indent_size`. A file formatted at two columns no longer gets
four-column continuations. `optimize_line_breaks` takes the width as an
optional argument so its existing callers are unaffected.

## Verification

`test_formatter_indent_size` formats a program with top-level declarations, a
`do` and a nested `if`, exercising both fortfront emission paths, at
`indent_size` 1, 2, 3, 4 and 8, and with a tab. It requires the shallowest
indent to equal the configured width and every indent to be a multiple of it.

`test_optimize_line_breaks` gains a case requiring a two-column continuation
when two columns were asked for.

Negative control: making `rescale_indentation` return its input unchanged
fails `test_formatter_indent_size` with "shallowest indent is not the
configured width" at 2, 3 and 8 and both tab assertions. Restoring the
hardcoded `+ 4` continuation indent fails `test_optimize_line_breaks` test 7
with six columns expected and eight produced.

Full `fo` pipeline green: 95 tests, lint, build.

## Not fixed here

- `[FAIL] Detection: modern Fortran - expected modern but detected standard`
  from the same suite. Separate defect in `select_style_guide`, untouched.
- Adjacent, found while measuring and pre-existing on main: a long expression
  that the line breaker splits comes back through fortfront's parser wrong. At
  four columns the trailing `+ gamma` is silently dropped from the re-parsed
  output; at two columns the break lands after the operator instead and the
  re-parse fails outright, so `format_source` returns the source untouched.
  Not caused by this change (the four-column path is byte-identical to main)
  but worth its own issue.