### PR TITLE
Make fluff format idempotent

### DIFF
--- a/src/fluff_cli/fluff_cli.f90
+++ b/src/fluff_cli/fluff_cli.f90
@@ -57,6 +57,7 @@ module fluff_cli
     public :: expand_file_arguments
     public :: path_matches_pattern
     public :: glob_match
+    public :: write_formatted_output
 
 contains
 
@@ -722,6 +723,7 @@ contains
     ! Run format command
     subroutine run_format_command(app, exit_code)
         use fluff_fix_applicator, only: read_text_file
+        use, intrinsic :: iso_fortran_env, only: output_unit
         type(cli_app_t), intent(inout) :: app
         integer, intent(out) :: exit_code
 
@@ -795,7 +797,7 @@ contains
                         exit_code = 1
                     end if
                 else
-                    print *, formatted_code
+                    call write_formatted_output(output_unit, formatted_code)
                 end if
             end do
         else
@@ -804,6 +806,23 @@ contains
         end if
 
     end subroutine run_format_command
+
+    subroutine write_formatted_output(unit, formatted_code)
+        !! Emit formatted source verbatim, followed by a single record
+        !! terminator.
+        !!
+        !! This used to be `print *, formatted_code`. List-directed output
+        !! prepends a blank to the record, so every formatted file came back
+        !! with a space in column 1 of its first line: `program p` became
+        !! ` program p`. Feeding that output back to the formatter is what
+        !! broke idempotence (issue #260). An explicit edit descriptor writes
+        !! the characters and nothing else.
+        integer, intent(in) :: unit
+        character(len=*), intent(in) :: formatted_code
+
+        write (unit, '(a)') formatted_code
+
+    end subroutine write_formatted_output
 
     subroutine read_raw_text_file(file_path, content, error_msg)
         character(len=*), intent(in) :: file_path

--- a/src/fluff_formatter/fluff_format_quality_improve.f90
+++ b/src/fluff_formatter/fluff_format_quality_improve.f90
@@ -203,6 +203,17 @@ contains
                     end if
                 end if
 
+                ! `+ - * /` are only binary operators when an operand stands on
+                ! each side. In `print *, i` the `*` is a format specifier, in
+                ! `write (*, fmt)` a unit specifier, in `character(len=*)` an
+                ! assumed length; spacing those produced `print * , i`, which
+                ! no style guide writes and which #260 reported. Requiring a
+                ! real operand on both sides leaves them alone.
+                if (.not. has_operands_on_both_sides(result, pos)) then
+                    pos = pos + 1
+                    cycle
+                end if
+
                 if (pos > 1 .and. result(pos-1:pos-1) /= " ") then
                     result = result(1:pos-1) // " " // result(pos:)
                     pos = pos + 1
@@ -219,6 +230,82 @@ contains
         code = result
 
     end subroutine improve_operator_spacing
+
+    logical function has_operands_on_both_sides(text, pos) result(is_binary)
+        !! True when the character at pos is flanked, on the same line, by
+        !! something that can end an operand on the left and something that can
+        !! start one on the right. Anything else (a comma, an opening or
+        !! closing parenthesis to the left, an `=`, the line edge) means the
+        !! character is punctuation or a specifier rather than a binary
+        !! operator, and must not be spaced.
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: pos
+
+        integer :: left, right
+
+        is_binary = .false.
+
+        left = neighbour_index(text, pos, -1)
+        if (left == 0) return
+        if (.not. can_end_operand(text(left:left))) return
+
+        right = neighbour_index(text, pos, 1)
+        if (right == 0) return
+        if (.not. can_start_operand(text(right:right))) return
+
+        is_binary = .true.
+
+    end function has_operands_on_both_sides
+
+    integer function neighbour_index(text, pos, step) result(idx)
+        !! Index of the nearest non-blank character from pos in direction step,
+        !! stopping at a line break. Zero when the line ends first.
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: pos, step
+        integer :: probe
+
+        idx = 0
+        probe = pos + step
+        do while (probe >= 1 .and. probe <= len(text))
+            if (text(probe:probe) == new_line("a")) return
+            if (text(probe:probe) /= " ") then
+                idx = probe
+                return
+            end if
+            probe = probe + step
+        end do
+
+    end function neighbour_index
+
+    logical function can_end_operand(c) result(can_end)
+        !! Characters that can terminate an operand: a name or number, a closing
+        !! bracket, a string delimiter, or the `.` of a real literal or of a
+        !! named operator such as `.true.`.
+        character, intent(in) :: c
+
+        can_end = is_name_char(c) .or. c == ")" .or. c == "]" .or. &
+            c == "'" .or. c == '"' .or. c == "." .or. c == "%"
+
+    end function can_end_operand
+
+    logical function can_start_operand(c) result(can_start)
+        !! Characters that can begin an operand. `(` and `[` appear here but not
+        !! in can_end_operand: `a*(b + c)` is multiplication, while `(*` in
+        !! `write (*, fmt)` has no left operand at all.
+        character, intent(in) :: c
+
+        can_start = is_name_char(c) .or. c == "(" .or. c == "[" .or. &
+            c == "'" .or. c == '"' .or. c == "." .or. c == "%"
+
+    end function can_start_operand
+
+    logical function is_name_char(c) result(is_name)
+        character, intent(in) :: c
+
+        is_name = (c >= "a" .and. c <= "z") .or. (c >= "A" .and. c <= "Z") .or. &
+            (c >= "0" .and. c <= "9") .or. c == "_"
+
+    end function is_name_char
 
     logical function is_two_char_operator(first, second)
         !! True when first//second is a Fortran operator whose first character

--- a/test/test_cli_format_stdout.f90
+++ b/test/test_cli_format_stdout.f90
@@ -1,0 +1,146 @@
+program test_cli_format_stdout
+    !! End-to-end coverage of the `fluff format` stdout path.
+    !!
+    !! Review of #260 found that the fix had no oracle where the defect actually
+    !! lived: reverting only the call site in run_format_command back to
+    !! `print *, formatted_code` left the whole suite green while the binary
+    !! reproduced the bug. The existing test calls write_formatted_output
+    !! directly, which verifies the helper rather than the command that uses it.
+    !!
+    !! These tests drive the built binary, so they fail if the command stops
+    !! calling the helper, whatever the helper itself does.
+    implicit none
+
+    integer :: n_pass, n_fail
+    character(len=512) :: bin
+
+    n_pass = 0
+    n_fail = 0
+
+    call locate_binary(bin)
+    if (len_trim(bin) == 0) then
+        write (*, '(a)') 'FAIL: could not locate the fluff binary this build produced'
+        error stop 1
+    end if
+
+    call require_first_line_has_no_leading_space(bin)
+    call require_output_is_idempotent(bin)
+
+    write (*, '(a,i0,a,i0,a)') 'cli_format_stdout: ', n_pass, ' pass, ', &
+        n_fail, ' fail'
+    if (n_fail > 0) error stop 1
+
+contains
+
+    subroutine assert(cond, msg)
+        logical, intent(in) :: cond
+        character(len=*), intent(in) :: msg
+
+        if (cond) then
+            n_pass = n_pass + 1
+        else
+            n_fail = n_fail + 1
+            write (*, '(a,a)') 'FAIL: ', msg
+        end if
+    end subroutine assert
+
+    subroutine locate_binary(path)
+        !! Resolve the binary this build produced. Deliberately not a glob over
+        !! one build tool's layout: #265 was filed because two tests did that
+        !! and ended up grading a stale artifact.
+        character(len=*), intent(out) :: path
+        character(len=512) :: candidate(2)
+        logical :: found
+        integer :: i
+
+        candidate(1) = 'build/fo/app/fluff'
+        candidate(2) = 'build/fo/bin/fluff'
+        path = ''
+        do i = 1, size(candidate)
+            inquire (file=trim(candidate(i)), exist=found)
+            if (found) then
+                path = candidate(i)
+                return
+            end if
+        end do
+    end subroutine locate_binary
+
+    subroutine write_fixture(path)
+        character(len=*), intent(in) :: path
+        integer :: u
+
+        open (newunit=u, file=trim(path), status='replace')
+        write (u, '(a)') 'program p'
+        write (u, '(a)') '    implicit none'
+        write (u, '(a)') '    integer :: i'
+        write (u, '(a)') '    i = 1'
+        write (u, '(a)') '    print *, i'
+        write (u, '(a)') 'end program p'
+        close (u)
+    end subroutine write_fixture
+
+    subroutine run_format(bin, src, out)
+        character(len=*), intent(in) :: bin, src, out
+
+        call execute_command_line('"'//trim(bin)//'" format "'//trim(src)// &
+            '" > "'//trim(out)//'" 2>/dev/null', wait=.true.)
+    end subroutine run_format
+
+    subroutine first_line(path, line)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(out) :: line
+        integer :: u, ios
+
+        line = ''
+        open (newunit=u, file=trim(path), status='old', iostat=ios)
+        if (ios /= 0) return
+        read (u, '(a)', iostat=ios) line
+        close (u)
+    end subroutine first_line
+
+    subroutine require_first_line_has_no_leading_space(bin)
+        !! The defect: list-directed output prepends a blank to the record, so
+        !! `program p` came back as ` program p`.
+        character(len=*), intent(in) :: bin
+        character(len=512) :: src, out, line
+
+        src = '/tmp/fluff_cli_fmt_src.f90'
+        out = '/tmp/fluff_cli_fmt_out.txt'
+        call write_fixture(src)
+        call run_format(bin, src, out)
+        call first_line(out, line)
+
+        call assert(len_trim(line) > 0, &
+            'the format command emitted something on stdout')
+        if (len_trim(line) == 0) return
+        call assert(line(1:1) /= ' ', &
+            'the first emitted line starts in column 1, got "'//trim(line)//'"')
+
+        call execute_command_line('rm -f "'//trim(src)//'" "'//trim(out)//'"')
+    end subroutine require_first_line_has_no_leading_space
+
+    subroutine require_output_is_idempotent(bin)
+        !! Formatting the formatter's own output must be a no-op. This is the
+        !! property #260 is about; the leading space broke it because the second
+        !! pass saw a differently-indented first line.
+        character(len=*), intent(in) :: bin
+        character(len=512) :: src, out1, out2
+        integer :: rc
+
+        src = '/tmp/fluff_cli_idem_src.f90'
+        out1 = '/tmp/fluff_cli_idem_1.f90'
+        out2 = '/tmp/fluff_cli_idem_2.txt'
+        call write_fixture(src)
+        call run_format(bin, src, out1)
+        call run_format(bin, out1, out2)
+
+        call execute_command_line('diff -q "'//trim(out1)//'" "'//trim(out2)// &
+            '" > /dev/null 2>&1', wait=.true., exitstat=rc)
+        call assert(rc == 0, &
+            'formatting the formatted output again changes nothing')
+
+        call execute_command_line('rm -f "'//trim(src)//'" "'//trim(out1)// &
+            '" "'//trim(out2)//'"')
+    end subroutine require_output_is_idempotent
+
+end program test_cli_format_stdout

--- a/test/test_cli_format_stdout.f90
+++ b/test/test_cli_format_stdout.f90
@@ -9,15 +9,26 @@ program test_cli_format_stdout
     !!
     !! These tests drive the built binary, so they fail if the command stops
     !! calling the helper, whatever the helper itself does.
+    !!
+    !! The binary comes from resolve_fluff_binary in test_support, which derives
+    !! it from the running test's own executable. Hardcoding a build layout is
+    !! what #265 was filed for, and the first version of this file did exactly
+    !! that in the other direction: it looked in fo's build tree and found
+    !! nothing under fpm, which is what CI runs.
+    use test_support, only: resolve_fluff_binary
     implicit none
 
     integer :: n_pass, n_fail
-    character(len=512) :: bin
+    character(len=:), allocatable :: bin
 
     n_pass = 0
     n_fail = 0
 
-    call locate_binary(bin)
+    call resolve_fluff_binary(bin)
+    if (.not. allocated(bin)) then
+        write (*, '(a)') 'FAIL: could not locate the fluff binary this build produced'
+        error stop 1
+    end if
     if (len_trim(bin) == 0) then
         write (*, '(a)') 'FAIL: could not locate the fluff binary this build produced'
         error stop 1
@@ -44,26 +55,6 @@ contains
         end if
     end subroutine assert
 
-    subroutine locate_binary(path)
-        !! Resolve the binary this build produced. Deliberately not a glob over
-        !! one build tool's layout: #265 was filed because two tests did that
-        !! and ended up grading a stale artifact.
-        character(len=*), intent(out) :: path
-        character(len=512) :: candidate(2)
-        logical :: found
-        integer :: i
-
-        candidate(1) = 'build/fo/app/fluff'
-        candidate(2) = 'build/fo/bin/fluff'
-        path = ''
-        do i = 1, size(candidate)
-            inquire (file=trim(candidate(i)), exist=found)
-            if (found) then
-                path = candidate(i)
-                return
-            end if
-        end do
-    end subroutine locate_binary
 
     subroutine write_fixture(path)
         character(len=*), intent(in) :: path

--- a/test/test_formatter_idempotence.f90
+++ b/test/test_formatter_idempotence.f90
@@ -1,0 +1,376 @@
+program test_formatter_idempotence
+    !! Idempotence is the property a formatter must have: run over source the
+    !! formatter itself produced, it must change nothing. Without it
+    !! `fluff format` cannot run in CI, cannot back a --check mode, and adds
+    !! diff noise on every invocation.
+    !!
+    !! Issue #260 reported two instances: a leading space prepended to the first
+    !! line, and `print *, i` rewritten to `print * , i`. Both are asserted by
+    !! name below, but the point of this program is the general property, over a
+    !! corpus:
+    !!
+    !!   1. formatting already-canonical source returns it byte for byte, and
+    !!   2. formatting twice gives the same bytes as formatting once.
+    !!
+    !! Property 2 applies to every corpus entry. Property 1 applies only to the
+    !! canonical corpus, because the rough corpus holds constructs the formatter
+    !! still rewrites in ways nobody would call canonical (see rough_entry).
+    use fluff_cli, only: write_formatted_output
+    use fluff_format_quality_improve, only: apply_aesthetic_improvements
+    use fluff_format_quality_types, only: create_aesthetic_settings
+    use fluff_formatter, only: formatter_engine_t
+    use test_support, only: make_temp_fortran_path, read_text_file, &
+        delete_file_if_exists
+    implicit none
+
+    integer, parameter :: N_CANONICAL = 3
+    integer, parameter :: N_ROUGH = 4
+
+    integer :: n_fail
+
+    n_fail = 0
+
+    call check_canonical_corpus()
+    call check_rough_corpus()
+    call check_spacing_boundaries()
+    call check_reported_defects()
+    call check_stdout_is_verbatim()
+
+    if (n_fail > 0) then
+        write (*, '(a,i0,a)') 'FAILED: ', n_fail, ' idempotence check(s)'
+        error stop 1
+    end if
+    write (*, '(a)') '[OK] formatter idempotence'
+
+contains
+
+    subroutine check_canonical_corpus()
+        !! Each entry is already in the formatter's output form, so a run over it
+        !! must be a no-op and a second run must agree with the first.
+        integer :: i
+
+        do i = 1, N_CANONICAL
+            call assert_unchanged(canonical_entry(i), canonical_name(i))
+            call assert_twice_equals_once(canonical_entry(i), canonical_name(i))
+            call assert_no_stray_spacing(canonical_entry(i), canonical_name(i))
+        end do
+    end subroutine check_canonical_corpus
+
+    subroutine check_rough_corpus()
+        !! These the formatter does rewrite. It may not settle on the form a
+        !! Fortran programmer would choose, but it must settle: the second run
+        !! has to agree with the first, and neither may emit the spacing
+        !! artefacts of #260.
+        integer :: i
+
+        do i = 1, N_ROUGH
+            call assert_twice_equals_once(rough_entry(i), rough_name(i))
+            call assert_no_stray_spacing(rough_entry(i), rough_name(i))
+        end do
+    end subroutine check_rough_corpus
+
+    function canonical_name(i) result(name)
+        integer, intent(in) :: i
+        character(len=:), allocatable :: name
+
+        select case (i)
+        case (1)
+            name = 'list-directed print in a loop'
+        case (2)
+            name = 'arithmetic operators'
+        case default
+            name = 'array constructor and subscripts'
+        end select
+    end function canonical_name
+
+    function canonical_entry(i) result(source)
+        integer, intent(in) :: i
+        character(len=:), allocatable :: source
+        character(len=1) :: nl
+
+        nl = new_line('a')
+
+        select case (i)
+        case (1)
+            ! Verbatim from issue #260.
+            source = &
+                'program p'//nl// &
+                '    implicit none'//nl// &
+                '    integer :: i'//nl// &
+                '    do i = 1, 3'//nl// &
+                '        print *, i'//nl// &
+                '    end do'//nl// &
+                'end program p'
+        case (2)
+            source = &
+                'program arith'//nl// &
+                '    implicit none'//nl// &
+                '    integer :: a, b, c'//nl// &
+                '    a = 2'//nl// &
+                '    b = 3'//nl// &
+                '    c = a * b + a / b - a**2'//nl// &
+                '    print *, c'//nl// &
+                'end program arith'
+        case default
+            source = &
+                'program arrays'//nl// &
+                '    implicit none'//nl// &
+                '    integer :: v(3)'//nl// &
+                '    integer :: k'//nl// &
+                '    v = [1, 2, 3]'//nl// &
+                '    k = v(1) + v(2) * v(3)'//nl// &
+                '    print *, k, v'//nl// &
+                'end program arrays'
+        end select
+    end function canonical_entry
+
+    function rough_name(i) result(name)
+        integer, intent(in) :: i
+        character(len=:), allocatable :: name
+
+        select case (i)
+        case (1)
+            name = 'module with an intent-bearing subroutine'
+        case (2)
+            name = 'assumed-length character dummy'
+        case (3)
+            name = 'if/else inside a loop'
+        case default
+            name = 'formatted write to the default unit'
+        end select
+    end function rough_name
+
+    function rough_entry(i) result(source)
+        !! Constructs the formatter does not leave alone. Entry 1 loses the body
+        !! indentation of a module procedure and gains an `implicit none` inside
+        !! it; entry 2 additionally spaces the `=` of `len=*`; entry 3 gains a
+        !! blank line before `else` and `end if`. Those are separate defects from
+        !! #260 and are not fixed here, so their output is not pinned; what is
+        !! pinned is that the formatter reaches a fixed point on them and does
+        !! not corrupt the `*` of a unit or format specifier.
+        integer, intent(in) :: i
+        character(len=:), allocatable :: source
+        character(len=1) :: nl
+
+        nl = new_line('a')
+
+        select case (i)
+        case (1)
+            source = &
+                'module m'//nl// &
+                '    implicit none'//nl// &
+                'contains'//nl// &
+                '    subroutine scale_value(x, factor)'//nl// &
+                '        integer, intent(inout) :: x'//nl// &
+                '        integer, intent(in) :: factor'//nl// &
+                '        x = x*factor'//nl// &
+                '    end subroutine scale_value'//nl// &
+                'end module m'
+        case (2)
+            source = &
+                'module names'//nl// &
+                '    implicit none'//nl// &
+                'contains'//nl// &
+                '    subroutine emit(text)'//nl// &
+                '        character(len=*), intent(in) :: text'//nl// &
+                '        print *, text'//nl// &
+                '    end subroutine emit'//nl// &
+                'end module names'
+        case (3)
+            source = &
+                'program nested'//nl// &
+                '    implicit none'//nl// &
+                '    integer :: i, total'//nl// &
+                '    total = 0'//nl// &
+                '    do i = 1, 10'//nl// &
+                '        if (i > 5) then'//nl// &
+                '            total = total + i'//nl// &
+                '        else'//nl// &
+                '            total = total - i'//nl// &
+                '        end if'//nl// &
+                '    end do'//nl// &
+                '    print *, total'//nl// &
+                'end program nested'
+        case default
+            source = &
+                'program shout'//nl// &
+                '    implicit none'//nl// &
+                '    write (*, ''(a)'') "hello"'//nl// &
+                'end program shout'
+        end select
+    end function rough_entry
+
+    subroutine check_spacing_boundaries()
+        !! The operator-spacing pass now asks whether an operand stands on each
+        !! side of `+ - * /`. These are the cases either side of that decision:
+        !! the first three must still be spaced, the rest must be left alone.
+        call assert_spacing('x=a*b', 'a * b', 'multiplication is still spaced')
+        call assert_spacing('x=a+b', 'a + b', 'addition is still spaced')
+        call assert_spacing('y=a*(b + c)', 'a * (b', 'operand may start with (')
+        call assert_spacing('print *, i', 'print *, i', 'list-directed print')
+        call assert_spacing('write (*, fmt) x', '(*, fmt)', 'unit specifier')
+        call assert_spacing('call emit(a, *)', ', *)', 'alternate return label')
+        call assert_spacing('x = -1', '= -1', 'unary minus is not an operand')
+    end subroutine check_spacing_boundaries
+
+    subroutine assert_spacing(source, expected, name)
+        character(len=*), intent(in) :: source, expected, name
+        character(len=:), allocatable :: code
+
+        call apply_aesthetic_improvements(source, code, &
+            create_aesthetic_settings())
+        if (index(code, expected) == 0) then
+            call fail(name//': expected "'//expected//'" in "'//show(code)// &
+                '" (from "'//source//'")')
+        end if
+    end subroutine assert_spacing
+
+    subroutine check_reported_defects()
+        !! The two instances named in issue #260, asserted directly so a
+        !! regression names itself.
+        character(len=:), allocatable :: source, formatted
+
+        source = canonical_entry(1)
+        call format_checked(source, formatted)
+
+        if (len(formatted) > 0) then
+            if (formatted(1:1) == ' ') then
+                call fail('first line gained a leading space: "'// &
+                    first_line(formatted)//'"')
+            end if
+        end if
+
+        if (index(formatted, 'print * ,') > 0) then
+            call fail('a space was inserted before the comma of a '// &
+                'list-directed print')
+        end if
+        if (index(formatted, 'print *, i') == 0) then
+            call fail('the list-directed print did not survive formatting')
+        end if
+    end subroutine check_reported_defects
+
+    subroutine check_stdout_is_verbatim()
+        !! `fluff format` writes the formatted source to stdout. The bytes it
+        !! writes must be the formatted source and nothing else: list-directed
+        !! output prepends a blank to the record, which is where the leading
+        !! space of issue #260 came from.
+        character(len=:), allocatable :: path, written, error_msg
+        character(len=:), allocatable :: payload
+        integer :: unit
+
+        payload = canonical_entry(1)
+
+        call make_temp_fortran_path('fmt_stdout', path)
+        open (newunit=unit, file=path, status='replace', action='write')
+        call write_formatted_output(unit, payload)
+        close (unit)
+
+        call read_text_file(path, written, error_msg)
+        call delete_file_if_exists(path)
+
+        if (error_msg /= '') then
+            call fail('could not read back the written output: '//error_msg)
+            return
+        end if
+
+        if (written /= payload//new_line('a')) then
+            call fail('formatted output was not written verbatim; first line '// &
+                'came out as "'//first_line(written)//'"')
+        end if
+    end subroutine check_stdout_is_verbatim
+
+    subroutine assert_unchanged(source, name)
+        character(len=*), intent(in) :: source, name
+        character(len=:), allocatable :: formatted
+
+        call format_checked(source, formatted)
+        if (formatted /= source) then
+            call fail(name//': already-formatted source was rewritten'// &
+                new_line('a')//'  expected: '//show(source)// &
+                new_line('a')//'  actual:   '//show(formatted))
+        end if
+    end subroutine assert_unchanged
+
+    subroutine assert_twice_equals_once(source, name)
+        character(len=*), intent(in) :: source, name
+        character(len=:), allocatable :: once, twice
+
+        call format_checked(source, once)
+        call format_checked(once, twice)
+        if (twice /= once) then
+            call fail(name//': second run differs from the first'// &
+                new_line('a')//'  run 1: '//show(once)// &
+                new_line('a')//'  run 2: '//show(twice))
+        end if
+    end subroutine assert_twice_equals_once
+
+    subroutine assert_no_stray_spacing(source, name)
+        !! No Fortran style writes a blank before a comma or a closing paren.
+        !! Either one means the operator-spacing pass mistook punctuation, or a
+        !! `*` that is a unit or format specifier, for a binary operator.
+        character(len=*), intent(in) :: source, name
+        character(len=:), allocatable :: formatted
+
+        call format_checked(source, formatted)
+        if (index(formatted, ' ,') > 0) then
+            call fail(name//': output has a space before a comma: '// &
+                show(formatted))
+        end if
+        if (index(formatted, ' )') > 0) then
+            call fail(name//': output has a space before a closing paren: '// &
+                show(formatted))
+        end if
+    end subroutine assert_no_stray_spacing
+
+    subroutine format_checked(source, formatted)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: formatted
+
+        type(formatter_engine_t) :: formatter
+        character(len=:), allocatable :: error_msg
+
+        call formatter%initialize()
+        call formatter%format_source(source, formatted, error_msg)
+        if (error_msg /= '') then
+            call fail('formatting failed: '//error_msg)
+            formatted = ''
+        end if
+    end subroutine format_checked
+
+    function show(text) result(display)
+        !! Newlines shown as \n so a failure stays on one diagnostic line.
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: display
+        integer :: i
+
+        display = ''
+        do i = 1, len(text)
+            if (text(i:i) == new_line('a')) then
+                display = display//'\n'
+            else
+                display = display//text(i:i)
+            end if
+        end do
+    end function show
+
+    function first_line(text) result(head)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: head
+        integer :: nl
+
+        nl = index(text, new_line('a'))
+        if (nl == 0) then
+            head = text
+        else
+            head = text(1:nl - 1)
+        end if
+    end function first_line
+
+    subroutine fail(message)
+        character(len=*), intent(in) :: message
+
+        n_fail = n_fail + 1
+        write (*, '(a)') 'FAIL: '//message
+    end subroutine fail
+
+end program test_formatter_idempotence


### PR DESCRIPTION
Closes #260.

## What was wrong

Running `fluff format` over source it had just produced changed that source. Two independent mechanisms:

1. **Leading space on the first line.** `run_format_command` printed its result with `print *, formatted_code`. List-directed output prepends a blank to the record, so `program p` came back as ` program p`. It is now written through an explicit edit descriptor, in `write_formatted_output`.

2. **`print *, i` became `print * , i`.** The operator-spacing pass treated every `+ - * /` as a binary operator. In `print *, i` the `*` is a format specifier, in `write (*, fmt)` a unit specifier, in `character(len=*)` an assumed length. Spacing now requires something that can end an operand on the left and something that can start one on the right, so those are left alone while `a*b` is still spaced to `a * b` and `x = -1` no longer becomes `x = - 1`.

## Test

`test/test_formatter_idempotence.f90` asserts the property, not the two instances:

- a **canonical corpus** (already in the formatter's output form) must come back byte for byte;
- **every** corpus entry, canonical or not, must satisfy `format(format(x)) == format(x)`, so the property survives changes to what the canonical form is;
- no output may contain a space before a comma or a closing paren;
- the bytes `fluff format` writes must equal the formatted source exactly;
- boundary cases either side of the new operand test: `a*b`, `a+b`, `a*(b + c)` still spaced; `print *,`, `write (*, fmt)`, `(a, *)`, `x = -1` left alone.

### Gate 1 - nothing broke

Full `fo` pipeline green: Static OK, Build OK, Tests OK (96 passed), Lint OK. Both changed source files were already fmt-clean and stayed so. End to end: formatting the issue's file leaves it byte-identical, and a second run matches the first.

### Gate 2 - it does something

- Making `has_operands_on_both_sides` return `.true.` unconditionally turns the pipeline **red**: `test_formatter_idempotence` fails 12 assertions (first one `list-directed print in a loop: already-formatted source was rewritten`, actual `print * , i`), and `test_tool_integration` fails too.
- Replacing `write (unit, '(a)')` with `write (unit, *)` in `write_formatted_output` turns it **red** with `formatted output was not written verbatim; first line came out as " program p"`.

## `--diff` help text disagrees with the code

`fluff --help` documents `--diff` as "show diffs instead of rewriting files", which implies the default for `format` is to rewrite files in place. The code does not do that: `fluff format FILE` writes the formatted source to stdout, and only `--fix` rewrites the file. Behaviour is unchanged here, as asked.

Which is intended: **the help text**. `format` rewriting in place by default, with `--diff` and `--check` as the non-destructive modes, is what fprettify, black and ruff format all do, and it is what the wording of `--diff` already promises users. The current stdout default makes `--fix` redundant with `format` and leaves "instead of rewriting files" describing something that never happens. Changing it is a behaviour change and belongs in its own issue.

## Adjacent defects found, not fixed

Recorded in the `rough_entry` comment in the test rather than left silent:

- a module procedure loses its body indentation and gains an `implicit none` inside it;
- `character(len=*)` is respaced to `character(len = *)`;
- a blank line is inserted before `else` and `end if` inside a loop;
- `1.0e-5` is still split into `1.0e - 5` by the operator-spacing pass: invalid Fortran, but idempotent, so out of this issue's scope.

All four are idempotent, so none of them violates the property this PR fixes.