### PR TITLE
Keep inline comments on their statements when formatting

### DIFF
--- a/src/fluff_formatter/fluff_format_comments.f90
+++ b/src/fluff_formatter/fluff_format_comments.f90
@@ -1,0 +1,351 @@
+module fluff_format_comments
+    !! Re-attachment of inline comments to the statements they document.
+    !!
+    !! The code generator emits statements from the AST, and a trailing comment
+    !! that the parser could not hang off a node is either dropped or emitted on
+    !! a line of its own. Either way the comment stops documenting its
+    !! statement. This pass compares the original source with the emitted text
+    !! and puts every trailing comment back on the emitted line that carries the
+    !! same statement, leaving standalone comments standalone.
+    implicit none
+    private
+
+    public :: preserve_inline_comments
+
+    type :: inline_comment_t
+        character(len=:), allocatable :: key
+        character(len=:), allocatable :: comment
+        logical :: attached = .false.
+    end type inline_comment_t
+
+    type :: text_line_t
+        character(len=:), allocatable :: text
+    end type text_line_t
+
+contains
+
+    subroutine preserve_inline_comments(source_code, formatted_code, result_code)
+        !! Copy trailing comments from source_code onto the matching statement
+        !! lines of formatted_code.
+        character(len=*), intent(in) :: source_code
+        character(len=*), intent(in) :: formatted_code
+        character(len=:), allocatable, intent(out) :: result_code
+
+        type(inline_comment_t), allocatable :: pending(:)
+        type(text_line_t), allocatable :: source_lines(:)
+        type(text_line_t), allocatable :: lines(:)
+        character(len=:), allocatable :: code, comment
+        integer :: i, next_pending, match
+
+        call split_lines(formatted_code, lines)
+        if (.not. allocated(lines)) then
+            result_code = formatted_code
+            return
+        end if
+
+        call split_lines(source_code, source_lines)
+        call collect_inline_comments(source_lines, pending)
+        if (size(pending) == 0) then
+            result_code = formatted_code
+            return
+        end if
+
+        next_pending = 1
+        do i = 1, size(lines)
+            call split_code_comment(lines(i)%text, code, comment)
+            if (len(comment) > 0) cycle
+            if (len_trim(code) == 0) cycle
+            if (ends_with_ampersand(code)) cycle
+            match = find_match(pending, next_pending, normalize_code(code))
+            if (match == 0) cycle
+            lines(i)%text = trim(lines(i)%text)//' '//pending(match)%comment
+            pending(match)%attached = .true.
+            next_pending = match + 1
+        end do
+
+        call drop_orphan_comments(source_lines, pending, lines)
+        call join_lines(lines, ends_with_newline(formatted_code), result_code)
+
+    end subroutine preserve_inline_comments
+
+    subroutine collect_inline_comments(source_lines, pending)
+        !! Gather every source line that carries both code and a comment.
+        type(text_line_t), intent(in) :: source_lines(:)
+        type(inline_comment_t), allocatable, intent(out) :: pending(:)
+
+        type(inline_comment_t), allocatable :: buffer(:)
+        character(len=:), allocatable :: code, comment
+        integer :: i, count
+
+        allocate (buffer(size(source_lines)))
+        count = 0
+
+        do i = 1, size(source_lines)
+            call split_code_comment(source_lines(i)%text, code, comment)
+            if (len(comment) == 0) cycle
+            if (len_trim(code) == 0) cycle
+            ! A comment after a continuation marker belongs to a physical line
+            ! the emitter folds away, so there is no statement to put it on.
+            if (ends_with_ampersand(code)) cycle
+            count = count + 1
+            buffer(count)%key = normalize_code(code)
+            buffer(count)%comment = comment
+            buffer(count)%attached = .false.
+        end do
+
+        allocate (pending(count))
+        do i = 1, count
+            pending(i) = buffer(i)
+        end do
+
+    end subroutine collect_inline_comments
+
+    integer function find_match(pending, from_index, key) result(match)
+        !! First unattached pending comment at or after from_index whose
+        !! statement matches key. Searching forward only keeps the emitted order
+        !! of repeated statements intact.
+        type(inline_comment_t), intent(in) :: pending(:)
+        integer, intent(in) :: from_index
+        character(len=*), intent(in) :: key
+
+        integer :: i
+
+        match = 0
+        if (len(key) == 0) return
+
+        do i = max(1, from_index), size(pending)
+            if (pending(i)%attached) cycle
+            if (pending(i)%key /= key) cycle
+            match = i
+            return
+        end do
+
+    end function find_match
+
+    subroutine drop_orphan_comments(source_lines, pending, lines)
+        !! Remove emitted standalone comment lines that only exist because the
+        !! emitter detached a comment we have now put back on its statement.
+        !! Comments that were standalone in the source are kept.
+        type(text_line_t), intent(in) :: source_lines(:)
+        type(inline_comment_t), intent(in) :: pending(:)
+        type(text_line_t), allocatable, intent(inout) :: lines(:)
+
+        type(text_line_t), allocatable :: kept(:)
+        character(len=:), allocatable :: code, comment
+        integer :: i, n_kept, allowed
+
+        allocate (kept(size(lines)))
+        n_kept = 0
+
+        do i = 1, size(lines)
+            call split_code_comment(lines(i)%text, code, comment)
+            if (len(comment) > 0 .and. len_trim(code) == 0) then
+                if (was_attached(pending, comment)) then
+                    allowed = count_standalone(source_lines, comment) - &
+                        count_standalone_kept(kept, n_kept, comment)
+                    if (allowed <= 0) cycle
+                end if
+            end if
+            n_kept = n_kept + 1
+            kept(n_kept)%text = lines(i)%text
+        end do
+
+        deallocate (lines)
+        allocate (lines(n_kept))
+        do i = 1, n_kept
+            lines(i) = kept(i)
+        end do
+
+    end subroutine drop_orphan_comments
+
+    logical function was_attached(pending, comment) result(found)
+        type(inline_comment_t), intent(in) :: pending(:)
+        character(len=*), intent(in) :: comment
+
+        integer :: i
+
+        found = .false.
+        do i = 1, size(pending)
+            if (.not. pending(i)%attached) cycle
+            if (pending(i)%comment /= comment) cycle
+            found = .true.
+            return
+        end do
+
+    end function was_attached
+
+    integer function count_standalone(source_lines, comment) result(count)
+        type(text_line_t), intent(in) :: source_lines(:)
+        character(len=*), intent(in) :: comment
+
+        character(len=:), allocatable :: code, line_comment
+        integer :: i
+
+        count = 0
+        do i = 1, size(source_lines)
+            call split_code_comment(source_lines(i)%text, code, line_comment)
+            if (len(line_comment) == 0) cycle
+            if (len_trim(code) /= 0) cycle
+            if (line_comment /= comment) cycle
+            count = count + 1
+        end do
+
+    end function count_standalone
+
+    integer function count_standalone_kept(kept, n_kept, comment) result(count)
+        type(text_line_t), intent(in) :: kept(:)
+        integer, intent(in) :: n_kept
+        character(len=*), intent(in) :: comment
+
+        character(len=:), allocatable :: code, line_comment
+        integer :: i
+
+        count = 0
+        do i = 1, n_kept
+            call split_code_comment(kept(i)%text, code, line_comment)
+            if (len(line_comment) == 0) cycle
+            if (len_trim(code) /= 0) cycle
+            if (line_comment /= comment) cycle
+            count = count + 1
+        end do
+
+    end function count_standalone_kept
+
+    subroutine split_code_comment(line, code, comment)
+        !! Split a line at its comment marker, ignoring bangs inside character
+        !! literals. comment keeps the bang and is trimmed of trailing blanks.
+        character(len=*), intent(in) :: line
+        character(len=:), allocatable, intent(out) :: code
+        character(len=:), allocatable, intent(out) :: comment
+
+        character(len=1) :: ch, quote
+        integer :: i
+        logical :: in_string
+
+        in_string = .false.
+        quote = ' '
+
+        do i = 1, len(line)
+            ch = line(i:i)
+            if (in_string) then
+                if (ch == quote) in_string = .false.
+                cycle
+            end if
+            if (ch == '"' .or. ch == "'") then
+                in_string = .true.
+                quote = ch
+                cycle
+            end if
+            if (ch /= '!') cycle
+            code = line(1:i - 1)
+            comment = trim(line(i:))
+            return
+        end do
+
+        code = line
+        comment = ""
+
+    end subroutine split_code_comment
+
+    function normalize_code(code) result(key)
+        !! Case-folded statement text with runs of blanks collapsed, so that
+        !! spacing and case changes made by the emitter still match.
+        character(len=*), intent(in) :: code
+        character(len=:), allocatable :: key
+
+        character(len=1) :: ch
+        integer :: i
+        logical :: pending_space
+
+        key = ""
+        pending_space = .false.
+
+        do i = 1, len_trim(code)
+            ch = code(i:i)
+            if (ch == ' ' .or. ch == achar(9)) then
+                if (len(key) > 0) pending_space = .true.
+                cycle
+            end if
+            if (pending_space) then
+                key = key//' '
+                pending_space = .false.
+            end if
+            if (ch >= 'A' .and. ch <= 'Z') ch = achar(iachar(ch) + 32)
+            key = key//ch
+        end do
+
+    end function normalize_code
+
+    logical function ends_with_ampersand(code) result(has_amp)
+        character(len=*), intent(in) :: code
+
+        has_amp = .false.
+        if (len_trim(code) == 0) return
+        has_amp = code(len_trim(code):len_trim(code)) == '&'
+
+    end function ends_with_ampersand
+
+    logical function ends_with_newline(text) result(has_newline)
+        character(len=*), intent(in) :: text
+
+        has_newline = .false.
+        if (len(text) == 0) return
+        has_newline = text(len(text):len(text)) == new_line('a')
+
+    end function ends_with_newline
+
+    subroutine split_lines(text, lines)
+        character(len=*), intent(in) :: text
+        type(text_line_t), allocatable, intent(out) :: lines(:)
+
+        integer :: i, count, start_pos, limit
+
+        limit = len(text)
+        if (limit > 0) then
+            if (text(limit:limit) == new_line('a')) limit = limit - 1
+        end if
+
+        count = 0
+        start_pos = 1
+        do i = 1, limit
+            if (text(i:i) /= new_line('a')) cycle
+            count = count + 1
+        end do
+        count = count + 1
+
+        allocate (lines(count))
+
+        count = 0
+        start_pos = 1
+        do i = 1, limit
+            if (text(i:i) /= new_line('a')) cycle
+            count = count + 1
+            lines(count)%text = text(start_pos:i - 1)
+            start_pos = i + 1
+        end do
+        count = count + 1
+        if (start_pos <= limit) then
+            lines(count)%text = text(start_pos:limit)
+        else
+            lines(count)%text = ""
+        end if
+
+    end subroutine split_lines
+
+    subroutine join_lines(lines, trailing_newline, text)
+        type(text_line_t), intent(in) :: lines(:)
+        logical, intent(in) :: trailing_newline
+        character(len=:), allocatable, intent(out) :: text
+
+        integer :: i
+
+        text = ""
+        do i = 1, size(lines)
+            if (i > 1) text = text//new_line('a')
+            text = text//lines(i)%text
+        end do
+        if (trailing_newline) text = text//new_line('a')
+
+    end subroutine join_lines
+
+end module fluff_format_comments

--- a/src/fluff_formatter/fluff_formatter.f90
+++ b/src/fluff_formatter/fluff_formatter.f90
@@ -5,6 +5,7 @@ module fluff_formatter
         apply_aesthetic_improvements, &
         assess_format_quality, create_aesthetic_settings, &
         create_quality_metrics, format_quality_t
+    use fluff_format_comments, only: preserve_inline_comments
     use fluff_format_continuation, only: has_leading_ampersand_continuations, &
         preserve_leading_ampersand_lines
     use fluff_format_indent, only: emitted_indent_width, rescale_indentation
@@ -200,6 +201,7 @@ contains
         character(len=:), allocatable :: next_code
         character(len=:), allocatable :: prev_code
         character(len=:), allocatable :: preserved_code
+        character(len=:), allocatable :: commented_code
         integer :: iter
         logical :: should_preserve
 
@@ -227,6 +229,9 @@ contains
             prev_code = current_code
             current_code = next_code
         end do
+
+        call preserve_inline_comments(source_code, current_code, commented_code)
+        current_code = commented_code
 
         if (should_preserve) then
             call preserve_leading_ampersand_lines(source_code, current_code, &

--- a/test/test_formatter_quality.f90
+++ b/test/test_formatter_quality.f90
@@ -16,6 +16,7 @@ program test_formatter_quality
     call test_semantic_preservation()
     call test_format_stability()
     call test_whitespace_normalization()
+    call test_inline_comment_preservation()
 
     print *, "[OK] All formatter quality tests passed!"
 
@@ -167,6 +168,124 @@ contains
         end if
 
     end subroutine test_format_stability
+
+    subroutine test_inline_comment_preservation()
+        !! An inline comment documents the statement it sits on. Formatting may
+        !! normalize the spacing before the bang, but detaching the comment from
+        !! its statement destroys that documentation, so every trailing comment
+        !! below must come back on a line that still carries its own statement.
+        print *, ""
+        print *, "Testing inline comment preservation..."
+
+        source_code = "program p"//new_line('a')// &
+            "    implicit none"//new_line('a')// &
+            "    integer :: x  ! count"//new_line('a')// &
+            "    integer :: y = 2  ! init"//new_line('a')// &
+            "    ! standalone"//new_line('a')// &
+            "    x = 1  ! set"//new_line('a')// &
+            "    if (x > 0) then  ! guard"//new_line('a')// &
+            "        print *, x  ! show"//new_line('a')// &
+            "    end if  ! done"//new_line('a')// &
+            "end program p  ! tail"//new_line('a')
+
+        call formatter%format_source(source_code, formatted_code, error_msg)
+        if (error_msg /= "") then
+            error stop "Formatting failed: "//error_msg
+        end if
+
+        call assert_inline_comment(formatted_code, "integer :: x", "! count")
+        call assert_inline_comment(formatted_code, "integer :: y", "! init")
+        call assert_inline_comment(formatted_code, "x = 1", "! set")
+        call assert_inline_comment(formatted_code, "if (x > 0) then", "! guard")
+        call assert_inline_comment(formatted_code, "print *, x", "! show")
+        call assert_inline_comment(formatted_code, "end if", "! done")
+        call assert_inline_comment(formatted_code, "end program p", "! tail")
+
+        ! A standalone comment stays standalone: it must not be glued onto the
+        ! statement that follows it.
+        call assert_standalone_comment(formatted_code, "! standalone")
+
+        print *, "[OK] Inline comments stay on their statements"
+
+    end subroutine test_inline_comment_preservation
+
+    subroutine assert_inline_comment(text, code_fragment, comment)
+        character(len=*), intent(in) :: text, code_fragment, comment
+        character(len=:), allocatable :: line
+        integer :: i, code_pos, comment_pos
+        logical :: found
+
+        found = .false.
+        do i = 1, count_lines(text)
+            line = get_line(text, i)
+            code_pos = index(line, code_fragment)
+            comment_pos = index(line, comment)
+            if (code_pos <= 0) cycle
+            if (comment_pos <= code_pos) cycle
+            found = .true.
+            exit
+        end do
+
+        if (.not. found) then
+            print *, "  Missing inline comment for: ", code_fragment
+            print *, "  Formatted output:"
+            print *, text
+            error stop "Inline comment detached from its statement"
+        end if
+
+    end subroutine assert_inline_comment
+
+    subroutine assert_standalone_comment(text, comment)
+        character(len=*), intent(in) :: text, comment
+        character(len=:), allocatable :: line
+        integer :: i, comment_pos
+        logical :: found
+
+        found = .false.
+        do i = 1, count_lines(text)
+            line = get_line(text, i)
+            comment_pos = index(line, comment)
+            if (comment_pos <= 0) cycle
+            if (len_trim(line(1:comment_pos - 1)) /= 0) then
+                print *, "  Standalone comment merged into a statement: ", line
+                error stop "Standalone comment must not join a statement"
+            end if
+            found = .true.
+        end do
+
+        if (.not. found) then
+            print *, "  Formatted output:"
+            print *, text
+            error stop "Standalone comment lost during formatting"
+        end if
+
+    end subroutine assert_standalone_comment
+
+    function get_line(text, line_number) result(line)
+        character(len=*), intent(in) :: text
+        integer, intent(in) :: line_number
+        character(len=:), allocatable :: line
+        integer :: i, current, start_pos
+
+        current = 1
+        start_pos = 1
+        line = ""
+
+        do i = 1, len(text)
+            if (text(i:i) /= new_line('a')) cycle
+            if (current == line_number) then
+                line = text(start_pos:i - 1)
+                return
+            end if
+            current = current + 1
+            start_pos = i + 1
+        end do
+
+        if (current == line_number .and. start_pos <= len(text)) then
+            line = text(start_pos:)
+        end if
+
+    end function get_line
 
     subroutine test_whitespace_normalization()
         integer :: trailing_spaces, inconsistent_spacing


### PR DESCRIPTION
Closes #244.

The emitter drops or detaches trailing comments, so `fo fmt` silently unhooks statement documentation. A new `fluff_format_comments` pass re-attaches every source trailing comment onto the emitted line carrying the same (case-folded, blank-collapsed) statement, in source order, and removes the orphan standalone lines the emitter created for those comments. Comments that were standalone in the source stay standalone; comments after a continuation ampersand are left alone.

Preserved invariant: formatting only normalizes spacing before the bang; it never moves a comment off its statement, and never merges a standalone comment into a neighbouring statement.

Red evidence (with the formatter hook reverted): test_formatter_quality FAILS -- `Missing inline comment for: end if`, output shows `! standalone`, `! done` detached onto their own lines.

Green evidence: `fo test test_formatter_quality` PASS; full `fo` pipeline: Static OK, Build OK, Tests OK (97 passed), Lint OK.